### PR TITLE
Add new Google Maps components and docs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,10 @@ module.exports = {
 		es2017: true,
 		node: true
 	},
+	rules: {
+		'no-undef': 'off',
+		'@typescript-eslint/no-inferrable-types': 'off'
+	},
 	overrides: [
 		{
 			files: ['*.svelte'],

--- a/apps/docs/src/routes/components/advanced-marker/+page.md
+++ b/apps/docs/src/routes/components/advanced-marker/+page.md
@@ -2,6 +2,10 @@
 title: AdvancedMarker
 ---
 
+## Storybook
+
+[Open the AdvancedMarker story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-advancedmarker--basic)
+
 The `AdvancedMarker` component creates and manages advanced markers on the map, allowing for custom HTML content.
 
 ## Props

--- a/apps/docs/src/routes/components/api-provider/+page.md
+++ b/apps/docs/src/routes/components/api-provider/+page.md
@@ -2,18 +2,34 @@
 title: APIProvider
 ---
 
+## Storybook
+
+[Open the APIProvider story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-apiprovider--basic)
+
 The `APIProvider` component is responsible for loading the Google Maps JavaScript API.
 
 ## Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| apiKey | string | | Google Maps API key (required) |
-| libraries | string[] | [] | Optional array of Google Maps libraries to load |
-| version | string | 'weekly' | Google Maps API version to load |
-| language | string | | Language for the Google Maps API |
-| region | string | | Region for the Google Maps API |
-| mapIds | string[] | [] | Map IDs for cloud-based map styling |
+| apiKey | `string` | `''` | Google Maps API key. |
+| googleMapsApiKey | `string` | | React-compatible API key alias. |
+| googleMapsClientId | `string` | | Google Maps Premium Plan client id. Do not use with an API key. |
+| libraries | `Library[]` | `[]` | Google Maps libraries to load. |
+| version | `string` | `'weekly'` | Google Maps API version to load. |
+| language | `string` | | Language for the Google Maps API. |
+| region | `string` | | Region for the Google Maps API. |
+| channel | `string` | | Usage tracking channel. |
+| mapIds | `string[]` | | Map IDs for cloud-based map styling. |
+| authReferrerPolicy | `'origin'` | | Auth referrer policy. |
+| apiUrl | `string` | `'https://maps.googleapis.com'` | Google Maps API base URL. |
+| solutionChannel | `string` | | Google solution channel. |
+| id | `string` | `'svelte-google-maps-api-script'` | Script element id. |
+| nonce | `string` | | CSP nonce for the script tag. |
+| preventGoogleFontsLoading | `boolean` | `false` | Prevents Google Maps from injecting its default font styles. |
+| onLoad | `() => void` | | Called when the script has loaded. |
+| onError | `(error: Error) => void` | | Called when the script fails to load. |
+| onUnmount | `() => void` | | Called when the provider is destroyed. |
 
 ## Usage
 
@@ -32,13 +48,7 @@ The `APIProvider` component is responsible for loading the Google Maps JavaScrip
 
 ## Context
 
-The `APIProvider` component sets a context that is consumed by child components:
-
-```javascript
-setContext('googleMap', { isReady });
-```
-
-This context is used by components like `GoogleMap` to know when the Google Maps API is loaded and ready to use.
+The `APIProvider` component sets the `svelte-google-maps-api` context with the load status, API reference, and error state. `GoogleMap` and service components use that context to wait for the script before creating Google Maps objects.
 
 ## Loading Multiple Libraries
 

--- a/apps/docs/src/routes/components/autocomplete/+page.md
+++ b/apps/docs/src/routes/components/autocomplete/+page.md
@@ -1,76 +1,55 @@
 ---
 title: Autocomplete
 ---
-The `Autocomplete` component provides a text input field that suggests geographic locations as the user types, leveraging the Google Places Autocomplete service.
 
-## Usage
+## Storybook
 
-First, ensure you load the `places` library via the `APIProvider`.
+[Open the Autocomplete story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-autocomplete--basic)
 
-```svelte
-<script lang="ts">
-  import { APIProvider, GoogleMap, Marker, Autocomplete } from 'svelte-google-maps-api';
-
-  let apiKey = 'YOUR_MAP_KEY'; // Replace with your API key
-  let map: google.maps.Map | null = null;
-  let selectedPlace: google.maps.places.PlaceResult | null = null;
-  let mapCenter = { lat: 35.681, lng: 139.767 }; // Default center (Tokyo)
-  let mapZoom = 12;
-
-  function handlePlaceChanged(event: CustomEvent<google.maps.places.PlaceResult>) {
-    const place = event.detail;
-    if (place.geometry?.location) {
-      selectedPlace = place;
-      // Update map center and zoom based on the selected place
-      mapCenter = place.geometry.location.toJSON();
-      mapZoom = 17;
-      console.log('Selected Place:', place.name, place.geometry.location.toJSON());
-    } else {
-      console.log('Returned place contains no geometry');
-    }
-  }
-</script>
-
-<div style="height: 500px; width: 100%; display: flex; flex-direction: column;">
-  <APIProvider {apiKey} libraries={['places']}>
-    <div style="padding: 10px;">
-      <Autocomplete
-        placeholder="Enter a location"
-        on:place_changed={handlePlaceChanged}
-        options={{
-          types: ['geocode'],
-          fields: ['name', 'geometry.location'] // Specify fields to reduce cost
-          // componentRestrictions: { country: 'jp' } // Example restriction
-        }}
-        style="width: 300px; padding: 8px; margin-bottom: 10px; font-size: 1rem;"
-      />
-    </div>
-
-    <div style="flex-grow: 1;">
-      <GoogleMap bind:map options={{ center: mapCenter, zoom: mapZoom, disableDefaultUI: true }}>
-        {#if selectedPlace && selectedPlace.geometry?.location}
-          <Marker position={selectedPlace.geometry.location} title={selectedPlace.name} />
-        {/if}
-      </GoogleMap>
-    </div>
-  </APIProvider>
-</div>
-```
+The `Autocomplete` component creates a Google Places autocomplete input.
 
 ## Props
 
-*(Specific props for the Svelte component need confirmation. Common ones include)*
-
-*   `options`: `google.maps.places.AutocompleteOptions` - Configuration for the Autocomplete service (e.g., types, fields, componentRestrictions).
-*   `placeholder`: `string` - Placeholder text for the input field.
-*   `style`: `string` - Inline styles for the input element.
-*   `class`: `string` - CSS classes for the input element.
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| options | `google.maps.places.AutocompleteOptions` | | Autocomplete options. |
+| value | `string` | `''` | Input value. |
+| placeholder | `string` | | Input placeholder. |
+| inputId | `string` | | Input id. |
+| inputClass | `string` | `''` | Input class. |
+| className | `string` | `''` | React-compatible class alias added to the input. |
+| inputStyle | `string` | `''` | Input inline style. |
+| disabled | `boolean` | `false` | Disables the input. |
+| bounds | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral` | | Result bias bounds. |
+| componentRestrictions | `google.maps.places.ComponentRestrictions` | | Component restrictions. |
+| restrictions | `google.maps.places.ComponentRestrictions` | | React-compatible alias for component restrictions. |
+| fields | `string[]` | | Place fields to return. |
+| strictBounds | `boolean` | | Restricts predictions to the bounds. |
+| types | `string[]` | | Place types. |
+| onPlaceChanged | `() => void` | | React-compatible place changed callback. |
+| onLoad | `(autocomplete: google.maps.places.Autocomplete) => void` | | Called after creation. |
+| onUnmount | `(autocomplete: google.maps.places.Autocomplete) => void` | | Called before teardown. |
 
 ## Events
 
-*   **`on:place_changed`**: Fired when a place is selected from the suggestions. The `event.detail` contains the `google.maps.places.PlaceResult`.
+The component dispatches `place_changed` with the selected `google.maps.places.PlaceResult`.
+
+## Usage
+
+```svelte
+<APIProvider apiKey="YOUR_API_KEY" libraries={['places']}>
+  <Autocomplete
+    placeholder="Enter a location"
+    fields={['name', 'geometry.location']}
+    inputStyle="width: 300px; padding: 8px;"
+    on:place_changed={(event) => {
+      selectedPlace = event.detail;
+    }}
+  />
+</APIProvider>
+```
 
 ## Notes
 
-*   Requires the `places` library to be loaded in `APIProvider`.
-*   Specify the `fields` option to request only the data you need, which can affect billing. See [Google Maps Platform documentation](https://developers.google.com/maps/documentation/javascript/places-autocomplete#specify-fields) for details. 
+- Requires `libraries={['places']}` on `APIProvider`.
+- Specify `fields` to request only the data you need.

--- a/apps/docs/src/routes/components/bicycling-layer/+page.md
+++ b/apps/docs/src/routes/components/bicycling-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: BicyclingLayer
 ---
+
+## Storybook
+
+[Open the BicyclingLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-bicyclinglayer--basic)
 The `BicyclingLayer` component displays bicycle paths, suggested routes, and other overlays specific to cycling on the map.
 
 ## Usage

--- a/apps/docs/src/routes/components/circle/+page.md
+++ b/apps/docs/src/routes/components/circle/+page.md
@@ -2,6 +2,10 @@
 title: Circle
 ---
 
+## Storybook
+
+[Open the Circle story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-circle--basic)
+
 The `Circle` component draws a circle on the map with a specified center and radius.
 
 ## Props

--- a/apps/docs/src/routes/components/data/+page.md
+++ b/apps/docs/src/routes/components/data/+page.md
@@ -1,0 +1,34 @@
+---
+title: Data
+---
+
+The `Data` component manages a `google.maps.Data` layer for GeoJSON features and feature-level events.
+
+## Storybook
+
+[Open the Data story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-data--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `google.maps.Data.DataOptions` | Initial Data layer options. `style`, `controls`, `controlPosition`, and `drawingMode` are also applied reactively. |
+| onLoad | `(data: google.maps.Data) => void` | Called after the Data layer is created. |
+| onUnmount | `(data: google.maps.Data) => void` | Called before the Data layer is removed. |
+
+## Events
+
+`onClick`, `onDblClick`, `onMouseDown`, `onMouseMove`, `onMouseOut`, `onMouseOver`, `onMouseUp`, `onRightClick`, `onAddFeature`, `onRemoveFeature`, `onRemoveProperty`, `onSetGeometry`, and `onSetProperty` map to the corresponding Google Maps Data events.
+
+## Usage
+
+```svelte
+<GoogleMap options={{ center, zoom: 12 }}>
+  <Data
+    onLoad={(data) => {
+      data.addGeoJson(geoJson);
+      data.setStyle({ fillColor: '#0f766e', strokeColor: '#0f766e' });
+    }}
+  />
+</GoogleMap>
+```

--- a/apps/docs/src/routes/components/directions-renderer/+page.md
+++ b/apps/docs/src/routes/components/directions-renderer/+page.md
@@ -1,0 +1,38 @@
+---
+title: DirectionsRenderer
+---
+
+The `DirectionsRenderer` component renders a `google.maps.DirectionsResult` on the current map.
+
+## Storybook
+
+[Open the DirectionsRenderer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-directionsrenderer--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| directions | `google.maps.DirectionsResult` | Directions result to render. |
+| options | `google.maps.DirectionsRendererOptions` | Renderer options. |
+| routeIndex | `number` | Route index to display. |
+| panel | `HTMLElement` | Optional directions panel element. |
+| draggable | `boolean` | Makes the rendered route draggable. |
+| hideRouteList | `boolean` | Hides the route list. |
+| preserveViewport | `boolean` | Keeps the current viewport. |
+| suppressMarkers | `boolean` | Suppresses default route markers. |
+| suppressInfoWindows | `boolean` | Suppresses default info windows. |
+| suppressPolylines | `boolean` | Suppresses default polylines. |
+| markerOptions | `google.maps.MarkerOptions` | Options for route markers. |
+| polylineOptions | `google.maps.PolylineOptions` | Options for route polylines. |
+| onDirectionsChanged | `() => void` | Called when renderer directions change. |
+| onLoad | `(renderer: google.maps.DirectionsRenderer) => void` | Called after creation. |
+| onUnmount | `(renderer: google.maps.DirectionsRenderer) => void` | Called before removal. |
+
+## Usage
+
+```svelte
+<DirectionsService options={request} callback={(result) => (directions = result ?? undefined)} />
+{#if directions}
+  <DirectionsRenderer {directions} />
+{/if}
+```

--- a/apps/docs/src/routes/components/directions-service/+page.md
+++ b/apps/docs/src/routes/components/directions-service/+page.md
@@ -1,0 +1,30 @@
+---
+title: DirectionsService
+---
+
+The `DirectionsService` component wraps `google.maps.DirectionsService` and calls `route` whenever `options` changes.
+
+## Storybook
+
+[Open the DirectionsService story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-directionsservice--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `google.maps.DirectionsRequest` | Route request. |
+| callback | `(result, status) => void` | Receives the route result and status. |
+| onLoad | `(service: google.maps.DirectionsService) => void` | Called after service creation. |
+| onUnmount | `(service: google.maps.DirectionsService) => void` | Called before teardown. |
+
+## Usage
+
+```svelte
+<DirectionsService
+  options={{ origin, destination, travelMode: 'DRIVING' }}
+  callback={(result, status) => {
+    directions = result ?? undefined;
+    console.log(status);
+  }}
+/>
+```

--- a/apps/docs/src/routes/components/distance-matrix-service/+page.md
+++ b/apps/docs/src/routes/components/distance-matrix-service/+page.md
@@ -1,0 +1,27 @@
+---
+title: DistanceMatrixService
+---
+
+The `DistanceMatrixService` component wraps `google.maps.DistanceMatrixService` and calls `getDistanceMatrix` whenever `options` changes.
+
+## Storybook
+
+[Open the DistanceMatrixService story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-distancematrixservice--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `google.maps.DistanceMatrixRequest` | Distance Matrix request. |
+| callback | `(response, status) => void` | Receives the response and status. |
+| onLoad | `(service: google.maps.DistanceMatrixService) => void` | Called after service creation. |
+| onUnmount | `(service: google.maps.DistanceMatrixService) => void` | Called before teardown. |
+
+## Usage
+
+```svelte
+<DistanceMatrixService
+  options={{ origins, destinations, travelMode: 'DRIVING' }}
+  callback={(response, status) => console.log(status, response)}
+/>
+```

--- a/apps/docs/src/routes/components/drawing-manager/+page.md
+++ b/apps/docs/src/routes/components/drawing-manager/+page.md
@@ -1,158 +1,41 @@
-# DrawingManager
+---
+title: DrawingManager
+---
 
-The `DrawingManager` component provides a graphical interface for users to draw overlays on the map, including markers, polylines, polygons, rectangles, and circles.
+## Storybook
 
-## Basic Usage
+[Open the DrawingManager story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-drawingmanager--basic)
 
-```svelte
-<script>
-  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
-</script>
-
-<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
-  <GoogleMap
-    zoom={12}
-    center={{ lat: 35.6812362, lng: 139.7649361 }}
-    options={{ mapTypeId: 'roadmap' }}
-  >
-    <DrawingManager
-      drawingControl={true}
-      drawingControlOptions={{
-        position: google.maps.ControlPosition.TOP_CENTER,
-        drawingModes: [
-          google.maps.drawing.OverlayType.MARKER,
-          google.maps.drawing.OverlayType.CIRCLE,
-          google.maps.drawing.OverlayType.POLYGON,
-          google.maps.drawing.OverlayType.POLYLINE,
-          google.maps.drawing.OverlayType.RECTANGLE
-        ]
-      }}
-    />
-  </GoogleMap>
-</APIProvider>
-```
+The `DrawingManager` component provides Google Maps drawing controls for markers, polylines, polygons, rectangles, and circles.
 
 ## Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `drawingMode` | `google.maps.drawing.OverlayType \| null` | `null` | The current drawing mode |
-| `drawingControl` | `boolean` | `true` | Whether the drawing control UI is displayed |
-| `drawingControlOptions` | `google.maps.drawing.DrawingControlOptions` | `undefined` | Options for the drawing control |
-| `circleOptions` | `google.maps.CircleOptions` | `undefined` | Default options for circles |
-| `markerOptions` | `google.maps.MarkerOptions` | `undefined` | Default options for markers |
-| `polygonOptions` | `google.maps.PolygonOptions` | `undefined` | Default options for polygons |
-| `polylineOptions` | `google.maps.PolylineOptions` | `undefined` | Default options for polylines |
-| `rectangleOptions` | `google.maps.RectangleOptions` | `undefined` | Default options for rectangles |
+| drawingMode | `google.maps.drawing.OverlayType \| null` | `null` | Active drawing mode. |
+| drawingControl | `boolean` | `true` | Shows the drawing control UI. |
+| drawingControlOptions | `google.maps.drawing.DrawingControlOptions` | | Drawing control options. |
+| markerOptions | `google.maps.MarkerOptions` | | Options for drawn markers. |
+| circleOptions | `google.maps.CircleOptions` | | Options for drawn circles. |
+| polygonOptions | `google.maps.PolygonOptions` | | Options for drawn polygons. |
+| polylineOptions | `google.maps.PolylineOptions` | | Options for drawn polylines. |
+| rectangleOptions | `google.maps.RectangleOptions` | | Options for drawn rectangles. |
+| onLoad | `(manager: google.maps.drawing.DrawingManager) => void` | | Called after creation. |
+| onUnmount | `(manager: google.maps.drawing.DrawingManager) => void` | | Called before teardown. |
 
 ## Events
 
-| Event | Type | Description |
-|-------|------|-------------|
-| `onCircleComplete` | `(circle: google.maps.Circle) => void` | Called when a circle is completed |
-| `onMarkerComplete` | `(marker: google.maps.Marker) => void` | Called when a marker is completed |
-| `onOverlayComplete` | `(event: google.maps.drawing.OverlayCompleteEvent) => void` | Called when any overlay is completed |
-| `onPolygonComplete` | `(polygon: google.maps.Polygon) => void` | Called when a polygon is completed |
-| `onPolylineComplete` | `(polyline: google.maps.Polyline) => void` | Called when a polyline is completed |
-| `onRectangleComplete` | `(rectangle: google.maps.Rectangle) => void` | Called when a rectangle is completed |
-| `onDrawingModeChange` | `() => void` | Called when the drawing mode changes |
-| `onLoad` | `(drawingManager: google.maps.drawing.DrawingManager) => void` | Called when the DrawingManager is loaded |
-| `onUnmount` | `(drawingManager: google.maps.drawing.DrawingManager) => void` | Called when the DrawingManager is unmounted |
+`onCircleComplete`, `onMarkerComplete`, `onOverlayComplete`, `onPolygonComplete`, `onPolylineComplete`, `onRectangleComplete`, and `onDrawingModeChange` map to the Google Maps drawing events.
 
-## Example with Custom Styling
+## Usage
 
 ```svelte
-<script>
-  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
-
-  let drawnShapes = [];
-
-  function handleOverlayComplete(event) {
-    drawnShapes.push(event.overlay);
-    // You can store the overlay for later manipulation
-    console.log('New shape drawn:', event.type);
-  }
-</script>
-
-<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
-  <GoogleMap
-    zoom={12}
-    center={{ lat: 35.6812362, lng: 139.7649361 }}
-    options={{ mapTypeId: 'roadmap' }}
-  >
+<APIProvider apiKey="YOUR_API_KEY" libraries={['drawing']}>
+  <GoogleMap options={{ center, zoom: 12 }}>
     <DrawingManager
-      drawingControl={true}
-      circleOptions={{
-        fillColor: '#ff0000',
-        fillOpacity: 0.35,
-        strokeWeight: 2,
-        clickable: true,
-        editable: true,
-        zIndex: 1
-      }}
-      polygonOptions={{
-        fillColor: '#00ff00',
-        fillOpacity: 0.35,
-        strokeWeight: 2,
-        clickable: true,
-        editable: true,
-        zIndex: 1
-      }}
-      rectangleOptions={{
-        fillColor: '#0000ff',
-        fillOpacity: 0.35,
-        strokeWeight: 2,
-        clickable: true,
-        editable: true,
-        zIndex: 1
-      }}
-      onOverlayComplete={handleOverlayComplete}
+      drawingControl
+      onOverlayComplete={(event) => console.log(event.type, event.overlay)}
     />
   </GoogleMap>
 </APIProvider>
-```
-
-## Drawing Mode Control
-
-You can programmatically control the drawing mode:
-
-```svelte
-<script>
-  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
-
-  let drawingMode = null;
-</script>
-
-<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
-  <div>
-    <button onclick={() => drawingMode = google.maps.drawing.OverlayType.MARKER}>
-      Draw Marker
-    </button>
-    <button onclick={() => drawingMode = google.maps.drawing.OverlayType.POLYGON}>
-      Draw Polygon
-    </button>
-    <button onclick={() => drawingMode = null}>
-      Stop Drawing
-    </button>
-  </div>
-  
-  <GoogleMap
-    zoom={12}
-    center={{ lat: 35.6812362, lng: 139.7649361 }}
-    options={{ mapTypeId: 'roadmap' }}
-  >
-    <DrawingManager
-      {drawingMode}
-      drawingControl={false}
-    />
-  </GoogleMap>
-</APIProvider>
-```
-
-## Note
-
-Remember to include the `drawing` library when initializing the API Provider:
-
-```svelte
-<APIProvider apiKey={YOUR_API_KEY} libraries={['drawing']}>
 ```

--- a/apps/docs/src/routes/components/google-map/+page.md
+++ b/apps/docs/src/routes/components/google-map/+page.md
@@ -2,6 +2,10 @@
 title: GoogleMap
 ---
 
+## Storybook
+
+[Open the GoogleMap story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-googlemap--basic)
+
 The GoogleMap component renders a Google Map instance.
 
 ## Props

--- a/apps/docs/src/routes/components/google-marker-clusterer/+page.md
+++ b/apps/docs/src/routes/components/google-marker-clusterer/+page.md
@@ -1,0 +1,29 @@
+---
+title: GoogleMarkerClusterer
+---
+
+The `GoogleMarkerClusterer` component wraps `@googlemaps/markerclusterer` and clusters child `Marker` or `AdvancedMarker` components.
+
+## Storybook
+
+[Open the GoogleMarkerClusterer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-googlemarkerclusterer--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `Omit<MarkerClustererOptions, 'map' \| 'markers'>` | Marker clusterer options. |
+| markers | `Marker[]` | Optional marker instances to cluster. Child markers register automatically. |
+| onClusterClick | `MarkerClustererOptions['onClusterClick']` | Cluster click handler. |
+| onLoad | `(clusterer) => void` | Called after clusterer creation. |
+| onUnmount | `(clusterer) => void` | Called before clusterer removal. |
+
+## Usage
+
+```svelte
+<GoogleMarkerClusterer>
+  {#each locations as position}
+    <Marker {position} />
+  {/each}
+</GoogleMarkerClusterer>
+```

--- a/apps/docs/src/routes/components/ground-overlay/+page.md
+++ b/apps/docs/src/routes/components/ground-overlay/+page.md
@@ -1,6 +1,10 @@
 ---
 title: GroundOverlay
 ---
+
+## Storybook
+
+[Open the GroundOverlay story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-groundoverlay--basic)
 A component to display an image on the map, fitted to the specified bounds.
 
 Must be used within a `<GoogleMap>` component.

--- a/apps/docs/src/routes/components/heatmap-layer/+page.md
+++ b/apps/docs/src/routes/components/heatmap-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: HeatmapLayer
 ---
+
+## Storybook
+
+[Open the HeatmapLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-heatmaplayer--basic)
 A component to display a heatmap layer on the map.
 Requires the `visualization` library. Please specify `libraries={['visualization']}` in the `<APIProvider>` props.
 

--- a/apps/docs/src/routes/components/info-box/+page.md
+++ b/apps/docs/src/routes/components/info-box/+page.md
@@ -1,0 +1,33 @@
+---
+title: InfoBox
+---
+
+The `InfoBox` component renders custom styled content in a Google Maps overlay pane.
+
+## Storybook
+
+[Open the InfoBox story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-infobox--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| anchor | `google.maps.MVCObject` | Optional anchor object. |
+| position | `google.maps.LatLng \| google.maps.LatLngLiteral` | Position used when no anchor is provided. |
+| options | `InfoBoxOptions` | InfoBox options such as `boxClass`, `boxStyle`, `pixelOffset`, and `closeBoxURL`. |
+| zIndex | `number` | Overlay z-index. |
+| isOpen | `boolean` | Opens or closes the InfoBox. |
+| onLoad | `(infoBox) => void` | Called after creation. |
+| onUnmount | `(infoBox) => void` | Called before removal. |
+
+## Events
+
+`onCloseClick`, `onDomReady`, `onContentChanged`, `onPositionChanged`, and `onZindexChanged` map to the corresponding InfoBox events.
+
+## Usage
+
+```svelte
+<InfoBox position={center} options={{ closeBoxURL: '', boxClass: 'info-box' }}>
+  <strong>Custom overlay content</strong>
+</InfoBox>
+```

--- a/apps/docs/src/routes/components/info-window/+page.md
+++ b/apps/docs/src/routes/components/info-window/+page.md
@@ -2,6 +2,10 @@
 title: InfoWindow
 ---
 
+## Storybook
+
+[Open the InfoWindow story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-infowindow--basic)
+
 The `InfoWindow` component creates and manages info windows on the map, which can display content when opened.
 
 ## Props

--- a/apps/docs/src/routes/components/kml-layer/+page.md
+++ b/apps/docs/src/routes/components/kml-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: KmlLayer
 ---
+
+## Storybook
+
+[Open the KmlLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-kmllayer--basic)
 A component to display data from a KML (Keyhole Markup Language) file on the map.
 
 Must be used within a `<GoogleMap>` component.

--- a/apps/docs/src/routes/components/map-control/+page.md
+++ b/apps/docs/src/routes/components/map-control/+page.md
@@ -1,6 +1,10 @@
 ---
 title: MapControl
 ---
+
+## Storybook
+
+[Open the MapControl story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-mapcontrol--basic)
 A component to add custom control elements to the map.
 Displays the HTML elements placed within its slot at the specified position.
 

--- a/apps/docs/src/routes/components/marker-clusterer/+page.md
+++ b/apps/docs/src/routes/components/marker-clusterer/+page.md
@@ -1,0 +1,30 @@
+---
+title: MarkerClusterer
+---
+
+The `MarkerClusterer` component clusters child markers. It uses the modern `@googlemaps/markerclusterer` implementation while keeping a React-compatible `onClick(cluster)` convenience prop.
+
+## Storybook
+
+[Open the MarkerClusterer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-markerclusterer--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `Omit<MarkerClustererOptions, 'map' \| 'markers'>` | Marker clusterer options. |
+| markers | `Marker[]` | Optional marker instances to cluster. Child markers register automatically. |
+| onClick | `(cluster) => void` | Convenience cluster click handler. |
+| onClusterClick | `MarkerClustererOptions['onClusterClick']` | Native cluster click handler. |
+| onLoad | `(clusterer) => void` | Called after clusterer creation. |
+| onUnmount | `(clusterer) => void` | Called before clusterer removal. |
+
+## Usage
+
+```svelte
+<MarkerClusterer onClick={(cluster) => console.log(cluster.count)}>
+  {#each locations as position}
+    <Marker {position} />
+  {/each}
+</MarkerClusterer>
+```

--- a/apps/docs/src/routes/components/marker/+page.md
+++ b/apps/docs/src/routes/components/marker/+page.md
@@ -2,6 +2,10 @@
 title: Marker
 ---
 
+## Storybook
+
+[Open the Marker story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-marker--basic)
+
 The `Marker` component creates and manages markers on the map.
 
 ## Props

--- a/apps/docs/src/routes/components/overlay-view/+page.md
+++ b/apps/docs/src/routes/components/overlay-view/+page.md
@@ -1,6 +1,10 @@
 ---
 title: OverlayView
 ---
+
+## Storybook
+
+[Open the OverlayView story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-overlayview--basic)
 A component for displaying custom HTML elements (`<slot>`) as an overlay at a specified position or bounds on the map.
 Wraps `google.maps.OverlayView` to integrate Svelte components into map panes.
 
@@ -40,6 +44,10 @@ Must be used within a `<GoogleMap>` component.
 | `position`    | `google.maps.LatLng \| google.maps.LatLngLiteral \| undefined`        | `undefined`   | The single geographical coordinate where the overlay should be displayed. If provided along with `bounds`, `position` takes precedence.                                              |
 | `bounds`      | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral \| undefined` | `undefined`   | The geographical bounds where the overlay should be displayed. If provided, the slot content will be stretched to fit these bounds. Used only if `position` is not provided.      |
 | `mapPaneName` | `keyof google.maps.MapPanes`                                       | `'floatPane'` | The name of the map pane where the overlay's container element should be added. See [MapPanes documentation](https://developers.google.com/maps/documentation/javascript/reference/map#MapPanes) for available pane names. |
+
+## Pane constants
+
+`FLOAT_PANE`, `MAP_PANE`, `MARKER_LAYER`, `OVERLAY_LAYER`, and `OVERLAY_MOUSE_TARGET` are exported from `svelte-google-maps-api` for convenient pane selection.
 
 **Note:** You cannot specify both `position` and `bounds` simultaneously. Provide one or the other, or neither (in which case the overlay won't be displayed).
 

--- a/apps/docs/src/routes/components/polygon/+page.md
+++ b/apps/docs/src/routes/components/polygon/+page.md
@@ -2,6 +2,10 @@
 title: Polygon
 ---
 
+## Storybook
+
+[Open the Polygon story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-polygon--basic)
+
 The `Polygon` component draws a closed shape on the map defined by a series of coordinates.
 
 ## Props

--- a/apps/docs/src/routes/components/polyline/+page.md
+++ b/apps/docs/src/routes/components/polyline/+page.md
@@ -2,6 +2,10 @@
 title: Polyline
 ---
 
+## Storybook
+
+[Open the Polyline story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-polyline--basic)
+
 The `Polyline` component draws a line on the map connecting a series of locations.
 
 ## Props

--- a/apps/docs/src/routes/components/rectangle/+page.md
+++ b/apps/docs/src/routes/components/rectangle/+page.md
@@ -2,6 +2,10 @@
 title: Rectangle
 ---
 
+## Storybook
+
+[Open the Rectangle story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-rectangle--basic)
+
 The `Rectangle` component draws a rectangle on the map defined by southwest and northeast coordinates.
 
 ## Props

--- a/apps/docs/src/routes/components/standalone-search-box/+page.md
+++ b/apps/docs/src/routes/components/standalone-search-box/+page.md
@@ -1,0 +1,40 @@
+---
+title: StandaloneSearchBox
+---
+
+The `StandaloneSearchBox` component wraps `google.maps.places.SearchBox` for free-form place search outside a map control.
+
+## Storybook
+
+[Open the StandaloneSearchBox story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-standalonesearchbox--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| bounds | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral` | Biases results to a bounds area. |
+| options | `google.maps.places.SearchBoxOptions` | Initial SearchBox options. |
+| value | `string` | Input value when using the built-in input. |
+| placeholder | `string` | Input placeholder when using the built-in input. |
+| inputId | `string` | Built-in input id. |
+| inputClass | `string` | Built-in input class. |
+| inputStyle | `string` | Built-in input inline style. |
+| disabled | `boolean` | Disables the built-in input. |
+| onPlacesChanged | `(places) => void` | Called when selected places change. |
+| onLoad | `(searchBox) => void` | Called after creation. |
+| onUnmount | `(searchBox) => void` | Called before teardown. |
+
+## Events
+
+The component also dispatches `places_changed` with the selected places.
+
+## Usage
+
+```svelte
+<APIProvider apiKey="YOUR_API_KEY" libraries={['places']}>
+  <StandaloneSearchBox
+    placeholder="Search places"
+    onPlacesChanged={(places) => console.log(places)}
+  />
+</APIProvider>
+```

--- a/apps/docs/src/routes/components/street-view-panorama/+page.md
+++ b/apps/docs/src/routes/components/street-view-panorama/+page.md
@@ -1,6 +1,10 @@
 ---
 title: StreetViewPanorama
 ---
+
+## Storybook
+
+[Open the StreetViewPanorama story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-streetviewpanorama--basic)
 A component to display Street View panoramas.
 
 Must be used within an `<APIProvider>` component.

--- a/apps/docs/src/routes/components/street-view-service/+page.md
+++ b/apps/docs/src/routes/components/street-view-service/+page.md
@@ -1,0 +1,28 @@
+---
+title: StreetViewService
+---
+
+The `StreetViewService` component creates a `google.maps.StreetViewService` instance for custom panorama lookups.
+
+## Storybook
+
+[Open the StreetViewService story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-streetviewservice--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| onLoad | `(service: google.maps.StreetViewService) => void` | Called after service creation. |
+| onUnmount | `(service: google.maps.StreetViewService) => void` | Called before teardown. |
+
+## Usage
+
+```svelte
+<StreetViewService
+  onLoad={(service) => {
+    service.getPanorama({ location: center, radius: 50 }, (data, status) => {
+      console.log(status, data);
+    });
+  }}
+/>
+```

--- a/apps/docs/src/routes/components/traffic-layer/+page.md
+++ b/apps/docs/src/routes/components/traffic-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: TrafficLayer
 ---
+
+## Storybook
+
+[Open the TrafficLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-trafficlayer--basic)
 A component to display the traffic layer on the map.
 
 Must be used within a `<GoogleMap>` component.

--- a/apps/docs/src/routes/components/transit-layer/+page.md
+++ b/apps/docs/src/routes/components/transit-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: TransitLayer
 ---
+
+## Storybook
+
+[Open the TransitLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-transitlayer--basic)
 The `TransitLayer` component displays the public transportation network on the map.
 
 ## Usage

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -2,6 +2,38 @@ import { defineConfig } from 'vite';
 import { sveltepress } from '@sveltepress/vite';
 import { defaultTheme } from '@sveltepress/theme-default';
 
+const componentItems = [
+	{ title: 'APIProvider', to: '/components/api-provider/' },
+	{ title: 'GoogleMap', to: '/components/google-map/' },
+	{ title: 'Marker', to: '/components/marker/' },
+	{ title: 'AdvancedMarker', to: '/components/advanced-marker/' },
+	{ title: 'MarkerClusterer', to: '/components/marker-clusterer/' },
+	{ title: 'GoogleMarkerClusterer', to: '/components/google-marker-clusterer/' },
+	{ title: 'InfoWindow', to: '/components/info-window/' },
+	{ title: 'InfoBox', to: '/components/info-box/' },
+	{ title: 'Polyline', to: '/components/polyline/' },
+	{ title: 'Polygon', to: '/components/polygon/' },
+	{ title: 'Circle', to: '/components/circle/' },
+	{ title: 'Rectangle', to: '/components/rectangle/' },
+	{ title: 'Data', to: '/components/data/' },
+	{ title: 'DrawingManager', to: '/components/drawing-manager/' },
+	{ title: 'DirectionsRenderer', to: '/components/directions-renderer/' },
+	{ title: 'DirectionsService', to: '/components/directions-service/' },
+	{ title: 'DistanceMatrixService', to: '/components/distance-matrix-service/' },
+	{ title: 'HeatmapLayer', to: '/components/heatmap-layer/' },
+	{ title: 'KmlLayer', to: '/components/kml-layer/' },
+	{ title: 'TrafficLayer', to: '/components/traffic-layer/' },
+	{ title: 'TransitLayer', to: '/components/transit-layer/' },
+	{ title: 'BicyclingLayer', to: '/components/bicycling-layer/' },
+	{ title: 'GroundOverlay', to: '/components/ground-overlay/' },
+	{ title: 'MapControl', to: '/components/map-control/' },
+	{ title: 'Autocomplete', to: '/components/autocomplete/' },
+	{ title: 'StandaloneSearchBox', to: '/components/standalone-search-box/' },
+	{ title: 'OverlayView', to: '/components/overlay-view/' },
+	{ title: 'StreetViewPanorama', to: '/components/street-view-panorama/' },
+	{ title: 'StreetViewService', to: '/components/street-view-service/' }
+];
+
 export default defineConfig({
 	// base パスは GitHub Pages 用なのでそのままで良いか確認が必要
 	base: '/svelte-google-maps-api/',
@@ -12,30 +44,7 @@ export default defineConfig({
 					{ title: 'Guide', to: '/guide/getting-started' },
 					{
 						title: 'Components',
-						items: [
-							{ title: 'APIProvider', to: '/components/api-provider/' },
-							{ title: 'GoogleMap', to: '/components/google-map/' },
-							{ title: 'Marker', to: '/components/marker/' },
-							{ title: 'AdvancedMarker', to: '/components/advanced-marker/' },
-							{ title: 'InfoWindow', to: '/components/info-window/' },
-							{ title: 'Polyline', to: '/components/polyline/' },
-							{ title: 'Polygon', to: '/components/polygon/' },
-							{ title: 'Circle', to: '/components/circle/' },
-							{ title: 'Rectangle', to: '/components/rectangle/' },
-							{ title: 'HeatmapLayer', to: '/components/heatmap-layer/' },
-							{ title: 'KmlLayer', to: '/components/kml-layer/' },
-							{ title: 'TrafficLayer', to: '/components/traffic-layer/' },
-							{ title: 'TransitLayer', to: '/components/transit-layer/' },
-							{ title: 'BicyclingLayer', to: '/components/bicycling-layer/' },
-							{ title: 'GroundOverlay', to: '/components/ground-overlay/' },
-							{ title: 'MapControl', to: '/components/map-control/' },
-							{ title: 'Autocomplete', to: '/components/autocomplete/' },
-							{ title: 'OverlayView', to: '/components/overlay-view/' },
-							{
-								title: 'StreetViewPanorama',
-								to: '/components/street-view-panorama/'
-							}
-						]
+						items: componentItems
 					},
 					{ title: 'Examples', to: '/examples' },
 					{
@@ -54,30 +63,7 @@ export default defineConfig({
 					'/components/': [
 						{
 							title: 'Components',
-							items: [
-								{ title: 'APIProvider', to: '/components/api-provider/' },
-								{ title: 'GoogleMap', to: '/components/google-map/' },
-								{ title: 'Marker', to: '/components/marker/' },
-								{ title: 'AdvancedMarker', to: '/components/advanced-marker/' },
-								{ title: 'InfoWindow', to: '/components/info-window/' },
-								{ title: 'Polyline', to: '/components/polyline/' },
-								{ title: 'Polygon', to: '/components/polygon/' },
-								{ title: 'Circle', to: '/components/circle/' },
-								{ title: 'Rectangle', to: '/components/rectangle/' },
-								{ title: 'HeatmapLayer', to: '/components/heatmap-layer/' },
-								{ title: 'KmlLayer', to: '/components/kml-layer/' },
-								{ title: 'TrafficLayer', to: '/components/traffic-layer/' },
-								{ title: 'TransitLayer', to: '/components/transit-layer/' },
-								{ title: 'BicyclingLayer', to: '/components/bicycling-layer/' },
-								{ title: 'GroundOverlay', to: '/components/ground-overlay/' },
-								{ title: 'MapControl', to: '/components/map-control/' },
-								{ title: 'Autocomplete', to: '/components/autocomplete/' },
-								{ title: 'OverlayView', to: '/components/overlay-view/' },
-								{
-									title: 'StreetViewPanorama',
-									to: '/components/street-view-panorama/'
-								}
-							]
+							items: componentItems
 						}
 					]
 				},

--- a/apps/storybook/.gitignore
+++ b/apps/storybook/.gitignore
@@ -1,0 +1,1 @@
+storybook-static

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,0 +1,23 @@
+import type { StorybookConfig } from '@storybook/svelte-vite';
+
+const config: StorybookConfig = {
+	stories: ['../src/**/*.stories.@(ts|svelte)'],
+	addons: [],
+	framework: {
+		name: '@storybook/svelte-vite',
+		options: {}
+	},
+	viteFinal: async (config) => {
+		const { svelte } = await import('@sveltejs/vite-plugin-svelte');
+
+		return {
+			...config,
+			plugins: [svelte(), ...(config.plugins ?? [])]
+		};
+	},
+	docs: {
+		autodocs: true
+	}
+};
+
+export default config;

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,0 +1,15 @@
+import type { Preview } from '@storybook/svelte';
+
+const preview: Preview = {
+	parameters: {
+		layout: 'fullscreen',
+		controls: {
+			matchers: {
+				color: /(background|color)$/i,
+				date: /Date$/i
+			}
+		}
+	}
+};
+
+export default preview;

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "storybook",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"scripts": {
+		"dev": "storybook dev -p 6006",
+		"build": "storybook build",
+		"storybook": "storybook dev -p 6006"
+	},
+	"dependencies": {
+		"svelte-google-maps-api": "workspace:*"
+	},
+	"devDependencies": {
+		"@sveltejs/vite-plugin-svelte": "^5.0.3",
+		"@storybook/svelte": "^8.6.14",
+		"@storybook/svelte-vite": "^8.6.14",
+		"storybook": "^8.6.14",
+		"svelte": "^5.28.2",
+		"typescript": "^5.0.0",
+		"vite": "^6.2.6"
+	}
+}

--- a/apps/storybook/src/stories/APIProvider.stories.ts
+++ b/apps/storybook/src/stories/APIProvider.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/APIProvider',
+	component: ComponentStory,
+	args: { componentName: 'APIProvider' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/AdvancedMarker.stories.ts
+++ b/apps/storybook/src/stories/AdvancedMarker.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/AdvancedMarker',
+	component: ComponentStory,
+	args: { componentName: 'AdvancedMarker' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Autocomplete.stories.ts
+++ b/apps/storybook/src/stories/Autocomplete.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Autocomplete',
+	component: ComponentStory,
+	args: { componentName: 'Autocomplete' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/BicyclingLayer.stories.ts
+++ b/apps/storybook/src/stories/BicyclingLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/BicyclingLayer',
+	component: ComponentStory,
+	args: { componentName: 'BicyclingLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Circle.stories.ts
+++ b/apps/storybook/src/stories/Circle.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Circle',
+	component: ComponentStory,
+	args: { componentName: 'Circle' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/ComponentStory.svelte
+++ b/apps/storybook/src/stories/ComponentStory.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+	import {
+		APIProvider,
+		AdvancedMarker,
+		Autocomplete,
+		BicyclingLayer,
+		Circle,
+		Data,
+		DirectionsRenderer,
+		DirectionsService,
+		DistanceMatrixService,
+		DrawingManager,
+		GoogleMap,
+		GoogleMarkerClusterer,
+		GroundOverlay,
+		HeatmapLayer,
+		InfoBox,
+		InfoWindow,
+		KmlLayer,
+		MapControl,
+		Marker,
+		MarkerClusterer,
+		OverlayView,
+		Polygon,
+		Polyline,
+		Rectangle,
+		StandaloneSearchBox,
+		StreetViewPanorama,
+		StreetViewService,
+		TrafficLayer,
+		TransitLayer
+	} from 'svelte-google-maps-api';
+	import type { Library } from 'svelte-google-maps-api';
+
+	export let componentName: string;
+
+	const apiKey = import.meta.env.STORYBOOK_GOOGLE_MAPS_API_KEY ?? '';
+	const center = { lat: 35.6812362, lng: 139.7649361 };
+	const second = { lat: 35.658584, lng: 139.7454316 };
+	const third = { lat: 35.710063, lng: 139.8107 };
+	const bounds = {
+		north: 35.73,
+		south: 35.64,
+		east: 139.84,
+		west: 139.69
+	};
+	const path = [center, second, third, center];
+	const mapOptions: google.maps.MapOptions = {
+		center,
+		zoom: 12,
+		mapId: 'DEMO_MAP_ID'
+	};
+	const heatmapData = [
+		{ location: center, weight: 3 },
+		{ location: second, weight: 2 },
+		{ location: third, weight: 4 }
+	];
+	const kmlUrl = 'https://developers.google.com/maps/documentation/javascript/examples/kml/westcampus.kml';
+	const groundOverlayUrl =
+		'https://developers.google.com/maps/documentation/javascript/examples/full/images/talkeetna.png';
+	const distanceRequest: google.maps.DistanceMatrixRequest = {
+		origins: [center],
+		destinations: [second],
+		travelMode: 'DRIVING' as google.maps.TravelMode
+	};
+	const directionsRequest: google.maps.DirectionsRequest = {
+		origin: center,
+		destination: second,
+		travelMode: 'DRIVING' as google.maps.TravelMode
+	};
+	const clusterLocations = [
+		center,
+		second,
+		third,
+		{ lat: 35.6895, lng: 139.6917 },
+		{ lat: 35.699, lng: 139.774 }
+	];
+
+	let directions: google.maps.DirectionsResult | undefined = undefined;
+	let serviceStatus = 'Waiting';
+	let dataLoaded = false;
+
+	$: libraries = getLibraries(componentName);
+
+	function getLibraries(name: string): Library[] {
+		if (name === 'Autocomplete' || name === 'StandaloneSearchBox') return ['places'];
+		if (name === 'DrawingManager') return ['drawing'];
+		if (name === 'HeatmapLayer') return ['visualization'];
+		if (name === 'AdvancedMarker') return ['marker'];
+		return [];
+	}
+
+	function handleDirectionsResult(
+		result: google.maps.DirectionsResult | null,
+		status: google.maps.DirectionsStatus
+	) {
+		serviceStatus = String(status);
+		if (result) directions = result;
+	}
+
+	function handleDistanceMatrix(
+		response: google.maps.DistanceMatrixResponse | null,
+		status: google.maps.DistanceMatrixStatus
+	) {
+		serviceStatus = response ? `${status}: ${response.rows.length} row` : String(status);
+	}
+
+	function handleDataLoad(data: google.maps.Data) {
+		data.addGeoJson({
+			type: 'FeatureCollection',
+			features: [
+				{
+					type: 'Feature',
+					geometry: {
+						type: 'Polygon',
+						coordinates: [
+							[
+								[139.72, 35.67],
+								[139.79, 35.67],
+								[139.79, 35.71],
+								[139.72, 35.71],
+								[139.72, 35.67]
+							]
+						]
+					},
+					properties: { name: 'Tokyo sample polygon' }
+				}
+			]
+		} as any);
+		data.setStyle({
+			fillColor: '#1d9a8a',
+			fillOpacity: 0.25,
+			strokeColor: '#1d9a8a',
+			strokeWeight: 2
+		});
+		dataLoaded = true;
+	}
+</script>
+
+{#if !apiKey}
+	<div class="missing-key">
+		<strong>{componentName}</strong>
+		<span>Set STORYBOOK_GOOGLE_MAPS_API_KEY to run this story with Google Maps.</span>
+	</div>
+{:else if componentName === 'APIProvider'}
+	<div class="map-frame">
+		<APIProvider {apiKey}>
+			<GoogleMap options={mapOptions} mapContainerStyle="width:100%;height:100%;">
+				<Marker position={center} options={{ title: 'APIProvider story marker' }} />
+			</GoogleMap>
+		</APIProvider>
+	</div>
+{:else if componentName === 'Autocomplete'}
+	<div class="panel-frame">
+		<APIProvider {apiKey} libraries={['places']}>
+			<Autocomplete placeholder="Search for a place" inputStyle="width:320px;padding:10px;" />
+		</APIProvider>
+	</div>
+{:else if componentName === 'StandaloneSearchBox'}
+	<div class="panel-frame">
+		<APIProvider {apiKey} libraries={['places']}>
+			<StandaloneSearchBox placeholder="Search places" inputStyle="width:320px;padding:10px;" />
+		</APIProvider>
+	</div>
+{:else if componentName === 'StreetViewPanorama'}
+	<div class="map-frame">
+		<APIProvider {apiKey}>
+			<StreetViewPanorama
+				position={center}
+				pov={{ heading: 165, pitch: 0 }}
+				zoom={1}
+				containerStyle="width:100%;height:100%;"
+			/>
+		</APIProvider>
+	</div>
+{:else if componentName === 'StreetViewService'}
+	<div class="panel-frame">
+		<APIProvider {apiKey}>
+			<StreetViewService onLoad={() => (serviceStatus = 'StreetViewService loaded')} />
+			<p>{serviceStatus}</p>
+		</APIProvider>
+	</div>
+{:else if componentName === 'DistanceMatrixService'}
+	<div class="panel-frame">
+		<APIProvider {apiKey}>
+			<DistanceMatrixService options={distanceRequest} callback={handleDistanceMatrix} />
+			<p>{serviceStatus}</p>
+		</APIProvider>
+	</div>
+{:else}
+	<div class="map-frame">
+		<APIProvider {apiKey} {libraries} mapIds={['DEMO_MAP_ID']}>
+			<GoogleMap options={mapOptions} mapContainerStyle="width:100%;height:100%;">
+				{#if componentName === 'GoogleMap'}
+					<Marker position={center} options={{ title: 'Tokyo Station' }} />
+				{:else if componentName === 'Marker'}
+					<Marker position={center} options={{ title: 'Marker', draggable: true }} />
+				{:else if componentName === 'AdvancedMarker'}
+					<AdvancedMarker position={center} title="Advanced marker">
+						<div class="advanced-marker">A</div>
+					</AdvancedMarker>
+				{:else if componentName === 'InfoWindow'}
+					<Marker position={center} />
+					<InfoWindow position={center}>
+						<strong>Tokyo Station</strong>
+					</InfoWindow>
+				{:else if componentName === 'InfoBox'}
+					<InfoBox
+						position={center}
+						options={{
+							boxClass: 'storybook-info-box',
+							pixelOffset: new google.maps.Size(-80, -40),
+							closeBoxURL: ''
+						}}
+					>
+						<div class="info-box">Custom InfoBox</div>
+					</InfoBox>
+				{:else if componentName === 'Polyline'}
+					<Polyline path={path} strokeColor="#0f766e" strokeWeight={4} />
+				{:else if componentName === 'Polygon'}
+					<Polygon paths={path} fillColor="#0f766e" fillOpacity={0.25} strokeColor="#0f766e" />
+				{:else if componentName === 'Circle'}
+					<Circle center={center} radius={1200} fillColor="#2563eb" fillOpacity={0.2} strokeColor="#2563eb" />
+				{:else if componentName === 'Rectangle'}
+					<Rectangle {bounds} fillColor="#f59e0b" fillOpacity={0.2} strokeColor="#f59e0b" />
+				{:else if componentName === 'Data'}
+					<Data onLoad={handleDataLoad} />
+					{#if dataLoaded}
+						<MapControl position={2 as google.maps.ControlPosition}>
+							<div class="control">Data loaded</div>
+						</MapControl>
+					{/if}
+				{:else if componentName === 'HeatmapLayer'}
+					<HeatmapLayer data={heatmapData} radius={32} opacity={0.7} />
+				{:else if componentName === 'KmlLayer'}
+					<KmlLayer url={kmlUrl} preserveViewport />
+				{:else if componentName === 'TrafficLayer'}
+					<TrafficLayer />
+				{:else if componentName === 'TransitLayer'}
+					<TransitLayer />
+				{:else if componentName === 'BicyclingLayer'}
+					<BicyclingLayer />
+				{:else if componentName === 'GroundOverlay'}
+					<GroundOverlay url={groundOverlayUrl} {bounds} opacity={0.55} />
+				{:else if componentName === 'OverlayView'}
+					<OverlayView position={center}>
+						<div class="overlay-view">OverlayView</div>
+					</OverlayView>
+				{:else if componentName === 'MapControl'}
+					<MapControl position={2 as google.maps.ControlPosition}>
+						<button class="control">Map control</button>
+					</MapControl>
+				{:else if componentName === 'DrawingManager'}
+					<DrawingManager drawingControl />
+				{:else if componentName === 'DirectionsRenderer'}
+					<DirectionsService options={directionsRequest} callback={handleDirectionsResult} />
+					{#if directions}
+						<DirectionsRenderer {directions} />
+					{/if}
+				{:else if componentName === 'DirectionsService'}
+					<DirectionsService options={directionsRequest} callback={handleDirectionsResult} />
+					<MapControl position={2 as google.maps.ControlPosition}>
+						<div class="control">Directions: {serviceStatus}</div>
+					</MapControl>
+				{:else if componentName === 'MarkerClusterer'}
+					<MarkerClusterer>
+						{#each clusterLocations as position}
+							<Marker {position} />
+						{/each}
+					</MarkerClusterer>
+				{:else if componentName === 'GoogleMarkerClusterer'}
+					<GoogleMarkerClusterer>
+						{#each clusterLocations as position}
+							<Marker {position} />
+						{/each}
+					</GoogleMarkerClusterer>
+				{/if}
+			</GoogleMap>
+		</APIProvider>
+	</div>
+{/if}
+
+<style>
+	.map-frame {
+		width: 100vw;
+		height: 100vh;
+	}
+
+	.panel-frame {
+		padding: 24px;
+		font-family:
+			Inter,
+			system-ui,
+			sans-serif;
+	}
+
+	.missing-key {
+		min-height: 100vh;
+		display: grid;
+		place-content: center;
+		gap: 8px;
+		font-family:
+			Inter,
+			system-ui,
+			sans-serif;
+		color: #1f2937;
+		background: #f8fafc;
+	}
+
+	.missing-key span {
+		color: #64748b;
+	}
+
+	.control,
+	.overlay-view,
+	.info-box {
+		background: white;
+		border: 1px solid #d1d5db;
+		border-radius: 6px;
+		box-shadow: 0 8px 24px rgba(15, 23, 42, 0.16);
+		color: #111827;
+		font: 14px/1.4 system-ui, sans-serif;
+		padding: 8px 12px;
+	}
+
+	.advanced-marker {
+		align-items: center;
+		background: #0f766e;
+		border: 2px solid white;
+		border-radius: 999px;
+		box-shadow: 0 6px 18px rgba(15, 23, 42, 0.22);
+		color: white;
+		display: flex;
+		font: 700 14px/1 system-ui, sans-serif;
+		height: 32px;
+		justify-content: center;
+		width: 32px;
+	}
+</style>

--- a/apps/storybook/src/stories/Data.stories.ts
+++ b/apps/storybook/src/stories/Data.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Data',
+	component: ComponentStory,
+	args: { componentName: 'Data' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DirectionsRenderer.stories.ts
+++ b/apps/storybook/src/stories/DirectionsRenderer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DirectionsRenderer',
+	component: ComponentStory,
+	args: { componentName: 'DirectionsRenderer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DirectionsService.stories.ts
+++ b/apps/storybook/src/stories/DirectionsService.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DirectionsService',
+	component: ComponentStory,
+	args: { componentName: 'DirectionsService' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DistanceMatrixService.stories.ts
+++ b/apps/storybook/src/stories/DistanceMatrixService.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DistanceMatrixService',
+	component: ComponentStory,
+	args: { componentName: 'DistanceMatrixService' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DrawingManager.stories.ts
+++ b/apps/storybook/src/stories/DrawingManager.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DrawingManager',
+	component: ComponentStory,
+	args: { componentName: 'DrawingManager' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/GoogleMap.stories.ts
+++ b/apps/storybook/src/stories/GoogleMap.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/GoogleMap',
+	component: ComponentStory,
+	args: { componentName: 'GoogleMap' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/GoogleMarkerClusterer.stories.ts
+++ b/apps/storybook/src/stories/GoogleMarkerClusterer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/GoogleMarkerClusterer',
+	component: ComponentStory,
+	args: { componentName: 'GoogleMarkerClusterer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/GroundOverlay.stories.ts
+++ b/apps/storybook/src/stories/GroundOverlay.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/GroundOverlay',
+	component: ComponentStory,
+	args: { componentName: 'GroundOverlay' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/HeatmapLayer.stories.ts
+++ b/apps/storybook/src/stories/HeatmapLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/HeatmapLayer',
+	component: ComponentStory,
+	args: { componentName: 'HeatmapLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/InfoBox.stories.ts
+++ b/apps/storybook/src/stories/InfoBox.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/InfoBox',
+	component: ComponentStory,
+	args: { componentName: 'InfoBox' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/InfoWindow.stories.ts
+++ b/apps/storybook/src/stories/InfoWindow.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/InfoWindow',
+	component: ComponentStory,
+	args: { componentName: 'InfoWindow' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/KmlLayer.stories.ts
+++ b/apps/storybook/src/stories/KmlLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/KmlLayer',
+	component: ComponentStory,
+	args: { componentName: 'KmlLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/MapControl.stories.ts
+++ b/apps/storybook/src/stories/MapControl.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/MapControl',
+	component: ComponentStory,
+	args: { componentName: 'MapControl' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Marker.stories.ts
+++ b/apps/storybook/src/stories/Marker.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Marker',
+	component: ComponentStory,
+	args: { componentName: 'Marker' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/MarkerClusterer.stories.ts
+++ b/apps/storybook/src/stories/MarkerClusterer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/MarkerClusterer',
+	component: ComponentStory,
+	args: { componentName: 'MarkerClusterer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/OverlayView.stories.ts
+++ b/apps/storybook/src/stories/OverlayView.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/OverlayView',
+	component: ComponentStory,
+	args: { componentName: 'OverlayView' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Polygon.stories.ts
+++ b/apps/storybook/src/stories/Polygon.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Polygon',
+	component: ComponentStory,
+	args: { componentName: 'Polygon' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Polyline.stories.ts
+++ b/apps/storybook/src/stories/Polyline.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Polyline',
+	component: ComponentStory,
+	args: { componentName: 'Polyline' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Rectangle.stories.ts
+++ b/apps/storybook/src/stories/Rectangle.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Rectangle',
+	component: ComponentStory,
+	args: { componentName: 'Rectangle' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/StandaloneSearchBox.stories.ts
+++ b/apps/storybook/src/stories/StandaloneSearchBox.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/StandaloneSearchBox',
+	component: ComponentStory,
+	args: { componentName: 'StandaloneSearchBox' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/StreetViewPanorama.stories.ts
+++ b/apps/storybook/src/stories/StreetViewPanorama.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/StreetViewPanorama',
+	component: ComponentStory,
+	args: { componentName: 'StreetViewPanorama' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/StreetViewService.stories.ts
+++ b/apps/storybook/src/stories/StreetViewService.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/StreetViewService',
+	component: ComponentStory,
+	args: { componentName: 'StreetViewService' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/TrafficLayer.stories.ts
+++ b/apps/storybook/src/stories/TrafficLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/TrafficLayer',
+	component: ComponentStory,
+	args: { componentName: 'TrafficLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/TransitLayer.stories.ts
+++ b/apps/storybook/src/stories/TransitLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/TransitLayer',
+	component: ComponentStory,
+	args: { componentName: 'TransitLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["@types/google.maps", "node"]
+	},
+	"include": [".storybook/**/*", "src/**/*"]
+}

--- a/packages/svelte-google-maps-api/.eslintignore
+++ b/packages/svelte-google-maps-api/.eslintignore
@@ -1,0 +1,3 @@
+dist
+.svelte-kit
+node_modules

--- a/packages/svelte-google-maps-api/.prettierignore
+++ b/packages/svelte-google-maps-api/.prettierignore
@@ -1,0 +1,3 @@
+dist
+.svelte-kit
+node_modules

--- a/packages/svelte-google-maps-api/package.json
+++ b/packages/svelte-google-maps-api/package.json
@@ -58,6 +58,10 @@
 			"types": "./dist/DirectionsRenderer.svelte.d.ts",
 			"svelte": "./dist/DirectionsRenderer.svelte"
 		},
+		"./DrawingManager.svelte": {
+			"types": "./dist/DrawingManager.svelte.d.ts",
+			"svelte": "./dist/DrawingManager.svelte"
+		},
 		"./MapControl.svelte": {
 			"types": "./dist/controls/MapControl.svelte.d.ts",
 			"svelte": "./dist/controls/MapControl.svelte"
@@ -97,6 +101,38 @@
 		"./Marker.svelte": {
 			"types": "./dist/Marker.svelte.d.ts",
 			"svelte": "./dist/Marker.svelte"
+		},
+		"./MarkerClusterer.svelte": {
+			"types": "./dist/MarkerClusterer.svelte.d.ts",
+			"svelte": "./dist/MarkerClusterer.svelte"
+		},
+		"./GoogleMarkerClusterer.svelte": {
+			"types": "./dist/GoogleMarkerClusterer.svelte.d.ts",
+			"svelte": "./dist/GoogleMarkerClusterer.svelte"
+		},
+		"./InfoBox.svelte": {
+			"types": "./dist/InfoBox.svelte.d.ts",
+			"svelte": "./dist/InfoBox.svelte"
+		},
+		"./Data.svelte": {
+			"types": "./dist/Data.svelte.d.ts",
+			"svelte": "./dist/Data.svelte"
+		},
+		"./DirectionsService.svelte": {
+			"types": "./dist/DirectionsService.svelte.d.ts",
+			"svelte": "./dist/DirectionsService.svelte"
+		},
+		"./DistanceMatrixService.svelte": {
+			"types": "./dist/DistanceMatrixService.svelte.d.ts",
+			"svelte": "./dist/DistanceMatrixService.svelte"
+		},
+		"./StandaloneSearchBox.svelte": {
+			"types": "./dist/places/StandaloneSearchBox.svelte.d.ts",
+			"svelte": "./dist/places/StandaloneSearchBox.svelte"
+		},
+		"./StreetViewService.svelte": {
+			"types": "./dist/street-view/StreetViewService.svelte.d.ts",
+			"svelte": "./dist/street-view/StreetViewService.svelte"
 		}
 	},
 	"files": [
@@ -117,6 +153,7 @@
 		"typescript": "^5.0.0"
 	},
 	"dependencies": {
+		"@googlemaps/markerclusterer": "^2.6.2",
 		"esm-env": "^1.0.0"
 	},
 	"keywords": [

--- a/packages/svelte-google-maps-api/src/lib/APIProvider.svelte
+++ b/packages/svelte-google-maps-api/src/lib/APIProvider.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-	import type { Library } from '$lib/types/googleMap.js';
+	import type { Library } from './types/googleMap.js';
 
 	type LoadStatus = 'loading' | 'loaded' | 'error';
 
@@ -14,79 +14,117 @@
 	import { BROWSER as browser } from 'esm-env';
 	import { setContext, onDestroy } from 'svelte';
 	import { writable, type Writable } from 'svelte/store';
+	import { preventGoogleFonts } from './utils/preventGoogleFonts.js';
 
 	export let apiKey = '';
+	export let googleMapsApiKey: string | undefined = undefined;
+	export let googleMapsClientId: string | undefined = undefined;
 	export let libraries: Library[] = [];
 	export let language: string | undefined = undefined;
 	export let region: string | undefined = undefined;
-	export let version: string | undefined = undefined;
+	export let version: string | undefined = 'weekly';
+	export let channel: string | undefined = undefined;
+	export let mapIds: string[] | undefined = undefined;
+	export let authReferrerPolicy: 'origin' | undefined = undefined;
+	export let apiUrl: string = 'https://maps.googleapis.com';
 	export let solutionChannel: string | undefined = undefined;
+	export let id: string = 'svelte-google-maps-api-script';
+	export let nonce: string | undefined = undefined;
+	export let preventGoogleFontsLoading: boolean = false;
+	export let onLoad: (() => void) | undefined = undefined;
+	export let onError: ((error: Error) => void) | undefined = undefined;
+	export let onUnmount: (() => void) | undefined = undefined;
 
 	let googleMapsApi: typeof google.maps | null = null;
 	let error: Error | null = null;
 
 	const statusStore = writable<LoadStatus>('loading');
 
-	const SCRIPT_ID = 'svelte-google-maps-api-script';
 	const CALLBACK_NAME = '__svelteGoogleMapApiCallback__';
 
 	let scriptElement: HTMLScriptElement | null = null;
+	type CallbackWindow = Window & Record<string, (() => void) | undefined>;
 
-	$: if (browser && !document.getElementById(SCRIPT_ID)) {
-		if (!apiKey) {
-			console.error('svelte-google-maps-api: apiKey is required for APIProvider');
+	$: if (browser && !document.getElementById(id)) {
+		const resolvedApiKey = googleMapsApiKey ?? apiKey;
+
+		if (resolvedApiKey && googleMapsClientId) {
+			const apiKeyError = new Error('Specify either apiKey/googleMapsApiKey or googleMapsClientId, not both');
+			console.error(`svelte-google-maps-api: ${apiKeyError.message}`);
 			statusStore.set('error');
-			error = new Error('apiKey is required');
+			error = apiKeyError;
+			onError?.(apiKeyError);
+		} else if (!resolvedApiKey && !googleMapsClientId) {
+			console.error('svelte-google-maps-api: apiKey or googleMapsClientId is required for APIProvider');
+			statusStore.set('error');
+			error = new Error('apiKey or googleMapsClientId is required');
+			onError?.(error);
 		} else {
 			statusStore.set('loading');
 			error = null;
 
-			window[CALLBACK_NAME] = () => {
+			const callbackWindow = window as unknown as CallbackWindow;
+
+			callbackWindow[CALLBACK_NAME] = () => {
 				googleMapsApi = window.google.maps;
 				statusStore.set('loaded');
+				onLoad?.();
 
 				try {
-					delete window[CALLBACK_NAME];
+					delete callbackWindow[CALLBACK_NAME];
 				} catch (e) {
-					window[CALLBACK_NAME] = undefined;
+					callbackWindow[CALLBACK_NAME] = undefined;
 				}
 			};
 
 			const script = document.createElement('script');
-			script.id = SCRIPT_ID;
+			script.id = id;
 			script.type = 'text/javascript';
+			if (nonce) script.nonce = nonce;
 			const params = new URLSearchParams();
-			params.set('key', apiKey);
+			if (resolvedApiKey) {
+				params.set('key', resolvedApiKey);
+			} else if (googleMapsClientId) {
+				params.set('client', googleMapsClientId);
+			}
 			params.set('callback', CALLBACK_NAME);
+			params.set('loading', 'async');
 			if (libraries.length > 0) {
-				params.set('libraries', libraries.sort().join(','));
+				params.set('libraries', [...libraries].sort().join(','));
 			}
 			if (language) params.set('language', language);
 			if (region) params.set('region', region);
 			if (version) params.set('v', version);
+			if (channel) params.set('channel', channel);
+			if (mapIds?.length) params.set('map_ids', mapIds.join(','));
+			if (authReferrerPolicy) params.set('auth_referrer_policy', authReferrerPolicy);
 			if (solutionChannel) params.set('solution_channel', solutionChannel);
 
-			script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
+			script.src = `${apiUrl.replace(/\/$/, '')}/maps/api/js?${params.toString()}`;
 			script.async = true;
 			script.defer = true;
 			script.onerror = (event: Event | string) => {
 				console.error('svelte-google-maps-api: Failed to load Google Maps API script.', event);
 				statusStore.set('error');
 				error = new Error(`Failed to load Google Maps script: ${event.toString()}`);
+				onError?.(error);
 
 				try {
-					delete window[CALLBACK_NAME];
+					delete callbackWindow[CALLBACK_NAME];
 				} catch (e) {
-					window[CALLBACK_NAME] = undefined;
+					callbackWindow[CALLBACK_NAME] = undefined;
 				}
 				if (scriptElement) document.head.removeChild(scriptElement);
 				scriptElement = null;
 			};
 
 			scriptElement = script;
+			if (preventGoogleFontsLoading) {
+				preventGoogleFonts();
+			}
 			document.head.appendChild(scriptElement);
 		}
-	} else if (browser && document.getElementById(SCRIPT_ID) && window.google && window.google.maps) {
+	} else if (browser && document.getElementById(id) && window.google && window.google.maps) {
 		statusStore.set('loaded');
 		googleMapsApi = window.google.maps;
 	}
@@ -99,13 +137,15 @@
 
 	onDestroy(() => {
 		if (browser) {
-			if (typeof window[CALLBACK_NAME] !== 'undefined') {
+			const callbackWindow = window as unknown as CallbackWindow;
+			if (typeof callbackWindow[CALLBACK_NAME] !== 'undefined') {
 				try {
-					delete window[CALLBACK_NAME];
+					delete callbackWindow[CALLBACK_NAME];
 				} catch (e) {
-					window[CALLBACK_NAME] = undefined;
+					callbackWindow[CALLBACK_NAME] = undefined;
 				}
 			}
+			onUnmount?.();
 		}
 	});
 </script>

--- a/packages/svelte-google-maps-api/src/lib/AdvancedMarker.svelte
+++ b/packages/svelte-google-maps-api/src/lib/AdvancedMarker.svelte
@@ -2,12 +2,15 @@
 	import { getContext, onDestroy, onMount, tick } from 'svelte';
 	import { BROWSER as browser } from 'esm-env';
 	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { ClusterableMarker, MarkerClustererContext } from './types/markerClusterer.js';
 
 	export let position: google.maps.LatLng | google.maps.LatLngLiteral | undefined = undefined;
 	export let title: string | undefined = undefined;
 	export let zIndex: number | undefined = undefined;
 	export let element: HTMLElement | undefined = undefined;
 	export let gmpDraggable: boolean | undefined = undefined;
+	export let options: Partial<google.maps.marker.AdvancedMarkerElementOptions> | undefined =
+		undefined;
 
 	export let onClick: ((e: google.maps.MapMouseEvent) => void) | undefined = undefined;
 	export let onDrag: ((e: google.maps.MapMouseEvent) => void) | undefined = undefined;
@@ -19,6 +22,7 @@
 		undefined;
 
 	let markerInstance: google.maps.marker.AdvancedMarkerElement | null = null;
+	let isClustered = false;
 	let contentWrapper: HTMLDivElement | null = null;
 	let clickListener: google.maps.MapsEventListener | null = null;
 	let dragListener: google.maps.MapsEventListener | null = null;
@@ -27,6 +31,7 @@
 
 	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
 	const map = getContext<google.maps.Map>('map');
+	const markerClusterer = getContext<MarkerClustererContext | undefined>('markerClusterer');
 
 	onDestroy(() => {
 		if (markerInstance) {
@@ -35,8 +40,13 @@
 			if (googleMapsApi) {
 				googleMapsApi.event.clearInstanceListeners(markerInstance);
 			}
-			markerInstance.map = null;
+			if (isClustered && markerClusterer) {
+				markerClusterer.removeMarker(markerInstance as ClusterableMarker);
+			} else {
+				markerInstance.map = null;
+			}
 			markerInstance = null;
+			isClustered = false;
 		}
 	});
 
@@ -60,16 +70,21 @@
 		}
 
 		const markerOptions: google.maps.marker.AdvancedMarkerElementOptions = {
-			map,
-			position,
-			title,
-			zIndex,
-			content: markerContent,
-			gmpDraggable
+			...(options ?? {}),
+			...(markerClusterer ? {} : { map }),
+			position: position ?? options?.position,
+			title: title ?? options?.title,
+			zIndex: zIndex ?? options?.zIndex,
+			content: markerContent ?? options?.content,
+			gmpDraggable: gmpDraggable ?? options?.gmpDraggable
 		};
 
 		try {
 			markerInstance = new googleMapsApi.marker.AdvancedMarkerElement(markerOptions);
+			if (markerClusterer) {
+				markerClusterer.addMarker(markerInstance as ClusterableMarker);
+				isClustered = true;
+			}
 			onLoad?.(markerInstance);
 		} catch (error) {
 			console.error('[AdvancedMarker] Error creating instance:', error);

--- a/packages/svelte-google-maps-api/src/lib/Circle.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Circle.svelte
@@ -101,24 +101,23 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onCenterChanged: 'center_changed',
-			onRadiusChanged: 'radius_changed',
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['center_changed', onCenterChanged],
+			['radius_changed', onRadiusChanged],
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(circleInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/Data.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Data.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let options: google.maps.Data.DataOptions | undefined = undefined;
+
+	export let onClick: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onDblClick: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseDown: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseMove: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseOut: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseOver: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseUp: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onRightClick: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onAddFeature: ((e: google.maps.Data.AddFeatureEvent) => void) | undefined = undefined;
+	export let onRemoveFeature: ((e: google.maps.Data.RemoveFeatureEvent) => void) | undefined =
+		undefined;
+	export let onRemoveProperty: ((e: google.maps.Data.RemovePropertyEvent) => void) | undefined =
+		undefined;
+	export let onSetGeometry: ((e: google.maps.Data.SetGeometryEvent) => void) | undefined =
+		undefined;
+	export let onSetProperty: ((e: google.maps.Data.SetPropertyEvent) => void) | undefined =
+		undefined;
+	export let onLoad: ((data: google.maps.Data) => void) | undefined = undefined;
+	export let onUnmount: ((data: google.maps.Data) => void) | undefined = undefined;
+
+	let data: google.maps.Data | null = null;
+	let listeners: google.maps.MapsEventListener[] = [];
+	let listenerDeps: unknown[] = [];
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	function clearListeners() {
+		if (!googleMapsApi) return;
+		listeners.forEach((listener) => googleMapsApi.event.removeListener(listener));
+		listeners = [];
+	}
+
+	function addListener<T>(
+		instance: google.maps.Data,
+		eventName: string,
+		handler: ((event: T) => void) | undefined
+	) {
+		if (handler && googleMapsApi) {
+			listeners.push(googleMapsApi.event.addListener(instance, eventName, handler));
+		}
+	}
+
+	function setupListeners() {
+		if (!data || !googleMapsApi) return;
+
+		clearListeners();
+		addListener<google.maps.Data.MouseEvent>(data, 'click', onClick);
+		addListener<google.maps.Data.MouseEvent>(data, 'dblclick', onDblClick);
+		addListener<google.maps.Data.MouseEvent>(data, 'mousedown', onMouseDown);
+		addListener<google.maps.Data.MouseEvent>(data, 'mousemove', onMouseMove);
+		addListener<google.maps.Data.MouseEvent>(data, 'mouseout', onMouseOut);
+		addListener<google.maps.Data.MouseEvent>(data, 'mouseover', onMouseOver);
+		addListener<google.maps.Data.MouseEvent>(data, 'mouseup', onMouseUp);
+		addListener<google.maps.Data.MouseEvent>(data, 'rightclick', onRightClick);
+		addListener<google.maps.Data.AddFeatureEvent>(data, 'addfeature', onAddFeature);
+		addListener<google.maps.Data.RemoveFeatureEvent>(data, 'removefeature', onRemoveFeature);
+		addListener<google.maps.Data.RemovePropertyEvent>(data, 'removeproperty', onRemoveProperty);
+		addListener<google.maps.Data.SetGeometryEvent>(data, 'setgeometry', onSetGeometry);
+		addListener<google.maps.Data.SetPropertyEvent>(data, 'setproperty', onSetProperty);
+	}
+
+	function applyOptions(nextOptions: google.maps.Data.DataOptions | undefined) {
+		if (!data || !nextOptions) return;
+
+		if (nextOptions.controlPosition !== undefined) {
+			data.setControlPosition(nextOptions.controlPosition);
+		}
+		if (nextOptions.controls !== undefined) {
+			data.setControls(nextOptions.controls);
+		}
+		if (nextOptions.drawingMode !== undefined) {
+			data.setDrawingMode(nextOptions.drawingMode);
+		}
+		if (nextOptions.style !== undefined) {
+			data.setStyle(nextOptions.style);
+		}
+	}
+
+	$: if ($status === 'loaded' && googleMapsApi && map && !data && browser) {
+		data = new googleMapsApi.Data({
+			...(options ?? {}),
+			map
+		});
+		setupListeners();
+		onLoad?.(data);
+	}
+
+	$: if (data && options) {
+		applyOptions(options);
+	}
+
+	$: listenerDeps = [
+		onClick,
+		onDblClick,
+		onMouseDown,
+		onMouseMove,
+		onMouseOut,
+		onMouseOver,
+		onMouseUp,
+		onRightClick,
+		onAddFeature,
+		onRemoveFeature,
+		onRemoveProperty,
+		onSetGeometry,
+		onSetProperty
+	];
+
+	$: if (data && googleMapsApi && browser && listenerDeps) {
+		setupListeners();
+	}
+
+	onDestroy(() => {
+		if (data) {
+			clearListeners();
+			onUnmount?.(data);
+			data.setMap(null);
+			data = null;
+		}
+	});
+</script>
+
+{#if data}
+	<slot />
+{/if}

--- a/packages/svelte-google-maps-api/src/lib/DirectionsService.svelte
+++ b/packages/svelte-google-maps-api/src/lib/DirectionsService.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let options: google.maps.DirectionsRequest;
+	export let callback: (
+		result: google.maps.DirectionsResult | null,
+		status: google.maps.DirectionsStatus
+	) => void;
+	export let onLoad: ((directionsService: google.maps.DirectionsService) => void) | undefined =
+		undefined;
+	export let onUnmount: ((directionsService: google.maps.DirectionsService) => void) | undefined =
+		undefined;
+
+	let directionsService: google.maps.DirectionsService | null = null;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	$: if ($status === 'loaded' && googleMapsApi && !directionsService && browser) {
+		directionsService = new googleMapsApi.DirectionsService();
+		onLoad?.(directionsService);
+	}
+
+	$: if (directionsService && options && callback) {
+		directionsService.route(options, callback);
+	}
+
+	onDestroy(() => {
+		if (directionsService) {
+			onUnmount?.(directionsService);
+			directionsService = null;
+		}
+	});
+</script>

--- a/packages/svelte-google-maps-api/src/lib/DistanceMatrixService.svelte
+++ b/packages/svelte-google-maps-api/src/lib/DistanceMatrixService.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let options: google.maps.DistanceMatrixRequest;
+	export let callback: (
+		response: google.maps.DistanceMatrixResponse | null,
+		status: google.maps.DistanceMatrixStatus
+	) => void;
+	export let onLoad:
+		| ((distanceMatrixService: google.maps.DistanceMatrixService) => void)
+		| undefined = undefined;
+	export let onUnmount:
+		| ((distanceMatrixService: google.maps.DistanceMatrixService) => void)
+		| undefined = undefined;
+
+	let distanceMatrixService: google.maps.DistanceMatrixService | null = null;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	$: if ($status === 'loaded' && googleMapsApi && !distanceMatrixService && browser) {
+		distanceMatrixService = new googleMapsApi.DistanceMatrixService();
+		onLoad?.(distanceMatrixService);
+	}
+
+	$: if (distanceMatrixService && options && callback) {
+		distanceMatrixService.getDistanceMatrix(options, callback);
+	}
+
+	onDestroy(() => {
+		if (distanceMatrixService) {
+			onUnmount?.(distanceMatrixService);
+			distanceMatrixService = null;
+		}
+	});
+</script>

--- a/packages/svelte-google-maps-api/src/lib/GoogleMarkerClusterer.svelte
+++ b/packages/svelte-google-maps-api/src/lib/GoogleMarkerClusterer.svelte
@@ -1,0 +1,94 @@
+<script context="module" lang="ts">
+	import type { MarkerClustererOptions as BaseMarkerClustererOptions } from '@googlemaps/markerclusterer';
+
+	export type MarkerClustererOptionsSubset = Omit<BaseMarkerClustererOptions, 'map' | 'markers'>;
+</script>
+
+<script lang="ts">
+	import { getContext, onDestroy, setContext } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import {
+		MarkerClusterer as GoogleMapsMarkerClusterer,
+		type Marker,
+		type MarkerClustererOptions
+	} from '@googlemaps/markerclusterer';
+	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { MarkerClustererContext } from './types/markerClusterer.js';
+
+	export let options: MarkerClustererOptionsSubset = {};
+	export let markers: Marker[] = [];
+	export let onClusterClick: MarkerClustererOptions['onClusterClick'] | undefined = undefined;
+	export let onLoad: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+	export let onUnmount: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+
+	let markerClusterer: GoogleMapsMarkerClusterer | null = null;
+	let registeredMarkers = new Set<Marker>();
+
+	const { status } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	function getClustererOptions(): MarkerClustererOptions {
+		return {
+			...options,
+			map,
+			...(onClusterClick ? { onClusterClick } : {})
+		};
+	}
+
+	function addMarker(marker: Marker) {
+		if (!markerClusterer || registeredMarkers.has(marker)) return;
+		registeredMarkers.add(marker);
+		markerClusterer.addMarker(marker, true);
+		markerClusterer.render();
+	}
+
+	function removeMarker(marker: Marker) {
+		if (!markerClusterer || !registeredMarkers.has(marker)) return;
+		markerClusterer.removeMarker(marker, true);
+		registeredMarkers.delete(marker);
+		markerClusterer.render();
+	}
+
+	setContext<MarkerClustererContext>('markerClusterer', {
+		addMarker,
+		removeMarker
+	});
+
+	function syncMarkers(nextMarkers: Marker[]) {
+		if (!markerClusterer) return;
+
+		for (const marker of Array.from(registeredMarkers)) {
+			if (!nextMarkers.includes(marker)) {
+				removeMarker(marker);
+			}
+		}
+
+		nextMarkers.forEach(addMarker);
+	}
+
+	$: if ($status === 'loaded' && map && !markerClusterer && browser) {
+		markerClusterer = new GoogleMapsMarkerClusterer(getClustererOptions());
+		syncMarkers(markers);
+		onLoad?.(markerClusterer);
+	}
+
+	$: if (markerClusterer && markers) {
+		syncMarkers(markers);
+	}
+
+	onDestroy(() => {
+		if (markerClusterer) {
+			onUnmount?.(markerClusterer);
+			markerClusterer.clearMarkers(true);
+			markerClusterer.setMap(null);
+			registeredMarkers.clear();
+			markerClusterer = null;
+		}
+	});
+</script>
+
+{#if markerClusterer}
+	<slot {markerClusterer} />
+{/if}

--- a/packages/svelte-google-maps-api/src/lib/GroundOverlay.svelte
+++ b/packages/svelte-google-maps-api/src/lib/GroundOverlay.svelte
@@ -56,13 +56,12 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onClick: 'click',
-			onDblClick: 'dblclick'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['dblclick', onDblClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(overlayInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/InfoBox.svelte
+++ b/packages/svelte-google-maps-api/src/lib/InfoBox.svelte
@@ -1,0 +1,370 @@
+<script context="module" lang="ts">
+	type Anchor = google.maps.MVCObject;
+
+	export type InfoBoxOptions = {
+		alignBottom?: boolean;
+		boxClass?: string;
+		boxStyle?: Partial<CSSStyleDeclaration>;
+		closeBoxMargin?: string;
+		closeBoxURL?: string;
+		content?: string | Node;
+		disableAutoPan?: boolean;
+		enableEventPropagation?: boolean;
+		infoBoxClearance?: google.maps.Size;
+		isHidden?: boolean;
+		maxWidth?: number;
+		pane?: keyof google.maps.MapPanes;
+		pixelOffset?: google.maps.Size;
+		position?: google.maps.LatLng;
+		visible?: boolean;
+		zIndex?: number;
+	};
+
+	export type InfoBoxInstance = google.maps.OverlayView & {
+		close: () => void;
+		getContent: () => string | Node | undefined;
+		getPosition: () => google.maps.LatLng | undefined;
+		getVisible: () => boolean;
+		getZIndex: () => number | undefined;
+		hide: () => void;
+		open: (map: google.maps.Map | google.maps.StreetViewPanorama, anchor?: Anchor) => void;
+		panBox: () => void;
+		setContent: (content: string | Node | undefined) => void;
+		setOptions: (options?: InfoBoxOptions) => void;
+		setPosition: (position: google.maps.LatLng) => void;
+		setVisible: (isVisible: boolean) => void;
+		setZIndex: (zIndex: number) => void;
+		show: () => void;
+	};
+</script>
+
+<script lang="ts">
+	import { getContext, onDestroy, onMount, tick } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let anchor: Anchor | undefined = undefined;
+	export let options: InfoBoxOptions | undefined = undefined;
+	export let position: google.maps.LatLng | google.maps.LatLngLiteral | undefined = undefined;
+	export let zIndex: number | undefined = undefined;
+	export let isOpen = true;
+
+	export let onCloseClick: (() => void) | undefined = undefined;
+	export let onDomReady: (() => void) | undefined = undefined;
+	export let onContentChanged: (() => void) | undefined = undefined;
+	export let onPositionChanged: (() => void) | undefined = undefined;
+	export let onZindexChanged: (() => void) | undefined = undefined;
+	export let onLoad: ((infoBox: InfoBoxInstance) => void) | undefined = undefined;
+	export let onUnmount: ((infoBox: InfoBoxInstance) => void) | undefined = undefined;
+
+	let infoBoxInstance: InfoBoxInstance | null = null;
+	let contentWrapper: HTMLDivElement | null = null;
+	let listeners: google.maps.MapsEventListener[] = [];
+	let listenerDeps: unknown[] = [];
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	onMount(() => {
+		tick().then(initializeInfoBox);
+	});
+
+	function toLatLng(
+		nextPosition: google.maps.LatLng | google.maps.LatLngLiteral | undefined
+	): google.maps.LatLng | undefined {
+		if (!nextPosition || !googleMapsApi) return undefined;
+		if (nextPosition instanceof googleMapsApi.LatLng) return nextPosition;
+		return new googleMapsApi.LatLng(nextPosition.lat, nextPosition.lng);
+	}
+
+	function createInfoBox(initialOptions: InfoBoxOptions): InfoBoxInstance {
+		if (!googleMapsApi) {
+			throw new Error('[InfoBox] Google Maps API is not loaded.');
+		}
+
+		const mapsApi = googleMapsApi;
+		const overlay = new mapsApi.OverlayView() as InfoBoxInstance;
+		const state = {
+			alignBottom: false,
+			boxClass: 'infoBox',
+			boxStyle: {} as Partial<CSSStyleDeclaration>,
+			closeBoxMargin: '2px',
+			closeBoxURL: 'https://www.google.com/intl/en_us/mapfiles/close.gif',
+			content: '' as string | Node | undefined,
+			domListeners: [] as Array<() => void>,
+			enableEventPropagation: false,
+			isVisible: true,
+			maxWidth: 0,
+			paneName: 'floatPane' as keyof google.maps.MapPanes,
+			pixelOffset: new mapsApi.Size(0, 0),
+			positionValue: undefined as google.maps.LatLng | undefined,
+			zIndexValue: undefined as number | undefined,
+			container: document.createElement('div')
+		};
+
+		state.container.style.position = 'absolute';
+
+		function getAnchorPosition(nextAnchor: Anchor | undefined): google.maps.LatLng | undefined {
+			if (!nextAnchor) return undefined;
+
+			const anchorWithPosition = nextAnchor as Anchor & {
+				getPosition?: () => google.maps.LatLng | undefined;
+				position?: google.maps.LatLng | google.maps.LatLngLiteral;
+			};
+			const nextPosition = anchorWithPosition.getPosition?.() ?? anchorWithPosition.position;
+
+			return toLatLng(nextPosition);
+		}
+
+		function preventMapEventPropagation() {
+			const events = [
+				'click',
+				'contextmenu',
+				'dblclick',
+				'mousedown',
+				'mousemove',
+				'mouseout',
+				'mouseover',
+				'mouseup',
+				'touchend',
+				'touchstart'
+			];
+
+			events.forEach((eventName) => {
+				const handler = (event: Event) => event.stopPropagation();
+				state.container.addEventListener(eventName, handler);
+				state.domListeners.push(() => state.container.removeEventListener(eventName, handler));
+			});
+		}
+
+		function render() {
+			state.domListeners.forEach((removeListener) => removeListener());
+			state.domListeners = [];
+			state.container.replaceChildren();
+			state.container.className = state.boxClass;
+			state.container.style.cssText = 'position:absolute;';
+			state.container.style.display = state.isVisible ? '' : 'none';
+			if (state.maxWidth > 0) state.container.style.maxWidth = `${state.maxWidth}px`;
+			if (state.zIndexValue !== undefined) {
+				state.container.style.zIndex = String(state.zIndexValue);
+			}
+			Object.assign(state.container.style, state.boxStyle);
+
+			if (!state.enableEventPropagation) {
+				preventMapEventPropagation();
+			}
+
+			if (state.closeBoxURL !== '') {
+				const closeButton = document.createElement('img');
+				closeButton.alt = 'Close';
+				closeButton.src = state.closeBoxURL;
+				closeButton.style.cssText = `cursor:pointer;float:right;margin:${state.closeBoxMargin};`;
+				closeButton.addEventListener('click', (event) => {
+					event.stopPropagation();
+					mapsApi.event.trigger(overlay, 'closeclick');
+					overlay.close();
+				});
+				state.container.appendChild(closeButton);
+			}
+
+			if (typeof state.content === 'string') {
+				const contentElement = document.createElement('div');
+				contentElement.innerHTML = state.content;
+				state.container.appendChild(contentElement);
+			} else if (state.content) {
+				state.container.appendChild(state.content);
+			}
+		}
+
+		overlay.onAdd = () => {
+			const pane = overlay.getPanes()?.[state.paneName];
+			if (!pane) return;
+
+			render();
+			pane.appendChild(state.container);
+			mapsApi.event.trigger(overlay, 'domready');
+		};
+
+		overlay.draw = () => {
+			const projection = overlay.getProjection();
+			if (!projection || !state.positionValue) return;
+
+			const point = projection.fromLatLngToDivPixel(state.positionValue);
+			if (!point) return;
+
+			state.container.style.left = `${point.x + state.pixelOffset.width}px`;
+			state.container.style.top = `${
+				point.y + state.pixelOffset.height - (state.alignBottom ? state.container.offsetHeight : 0)
+			}px`;
+		};
+
+		overlay.onRemove = () => {
+			state.domListeners.forEach((removeListener) => removeListener());
+			state.domListeners = [];
+
+			if (state.container.parentNode) {
+				state.container.parentNode.removeChild(state.container);
+			}
+		};
+
+		overlay.close = () => overlay.setMap(null);
+		overlay.getContent = () => state.content;
+		overlay.getPosition = () => state.positionValue;
+		overlay.getVisible = () => state.isVisible;
+		overlay.getZIndex = () => state.zIndexValue;
+		overlay.hide = () => overlay.setVisible(false);
+		overlay.open = (nextMap, nextAnchor) => {
+			const anchorPosition = getAnchorPosition(nextAnchor);
+			if (anchorPosition) {
+				overlay.setPosition(anchorPosition);
+			}
+
+			overlay.setMap(nextMap);
+		};
+		overlay.panBox = () => undefined;
+		overlay.setContent = (nextContent) => {
+			state.content = nextContent;
+			render();
+			mapsApi.event.trigger(overlay, 'content_changed');
+		};
+		overlay.setOptions = (nextOptions: InfoBoxOptions = {}) => {
+			if (nextOptions.alignBottom !== undefined) state.alignBottom = nextOptions.alignBottom;
+			if (nextOptions.boxClass !== undefined) state.boxClass = nextOptions.boxClass;
+			if (nextOptions.boxStyle !== undefined) state.boxStyle = nextOptions.boxStyle;
+			if (nextOptions.closeBoxMargin !== undefined)
+				state.closeBoxMargin = nextOptions.closeBoxMargin;
+			if (nextOptions.closeBoxURL !== undefined) state.closeBoxURL = nextOptions.closeBoxURL;
+			if (nextOptions.enableEventPropagation !== undefined) {
+				state.enableEventPropagation = nextOptions.enableEventPropagation;
+			}
+			if (nextOptions.maxWidth !== undefined) state.maxWidth = nextOptions.maxWidth;
+			if (nextOptions.pane !== undefined) state.paneName = nextOptions.pane;
+			if (nextOptions.pixelOffset !== undefined) state.pixelOffset = nextOptions.pixelOffset;
+			if (nextOptions.position !== undefined) overlay.setPosition(nextOptions.position);
+			if (nextOptions.visible !== undefined) overlay.setVisible(nextOptions.visible);
+			if (nextOptions.isHidden !== undefined) overlay.setVisible(!nextOptions.isHidden);
+			if (nextOptions.zIndex !== undefined) overlay.setZIndex(nextOptions.zIndex);
+			if (nextOptions.content !== undefined) overlay.setContent(nextOptions.content);
+
+			render();
+			overlay.draw();
+		};
+		overlay.setPosition = (nextPosition) => {
+			state.positionValue = nextPosition;
+			overlay.draw();
+			mapsApi.event.trigger(overlay, 'position_changed');
+		};
+		overlay.setVisible = (nextVisible) => {
+			state.isVisible = nextVisible;
+			state.container.style.display = nextVisible ? '' : 'none';
+		};
+		overlay.setZIndex = (nextZIndex) => {
+			state.zIndexValue = nextZIndex;
+			state.container.style.zIndex = String(nextZIndex);
+			mapsApi.event.trigger(overlay, 'zindex_changed');
+		};
+		overlay.show = () => overlay.setVisible(true);
+
+		overlay.setOptions(initialOptions);
+
+		return overlay;
+	}
+
+	function clearListeners() {
+		if (!googleMapsApi) return;
+		listeners.forEach((listener) => googleMapsApi.event.removeListener(listener));
+		listeners = [];
+	}
+
+	function addListener(eventName: string, handler: (() => void) | undefined) {
+		if (infoBoxInstance && handler && googleMapsApi) {
+			listeners.push(googleMapsApi.event.addListener(infoBoxInstance, eventName, handler));
+		}
+	}
+
+	function setupListeners() {
+		if (!infoBoxInstance || !googleMapsApi) return;
+
+		clearListeners();
+		addListener('closeclick', onCloseClick);
+		addListener('domready', onDomReady);
+		addListener('content_changed', onContentChanged);
+		addListener('position_changed', onPositionChanged);
+		addListener('zindex_changed', onZindexChanged);
+	}
+
+	function openInfoBox() {
+		if (!infoBoxInstance || !map) return;
+
+		if (!isOpen) {
+			infoBoxInstance.close();
+			return;
+		}
+
+		if (anchor) {
+			infoBoxInstance.open(map, anchor);
+		} else if (infoBoxInstance.getPosition()) {
+			infoBoxInstance.open(map);
+		}
+	}
+
+	function initializeInfoBox() {
+		if (!browser || $status !== 'loaded' || !googleMapsApi || !map || infoBoxInstance) return;
+
+		infoBoxInstance = createInfoBox({
+			...(options ?? {}),
+			content: contentWrapper ?? options?.content,
+			position: toLatLng(position ?? options?.position),
+			zIndex: zIndex ?? options?.zIndex
+		});
+		setupListeners();
+		openInfoBox();
+		onLoad?.(infoBoxInstance);
+	}
+
+	$: if ($status === 'loaded' && !infoBoxInstance) {
+		tick().then(initializeInfoBox);
+	}
+
+	$: if (infoBoxInstance && options) {
+		infoBoxInstance.setOptions(options);
+	}
+
+	$: if (infoBoxInstance && position) {
+		const nextPosition = toLatLng(position);
+		if (nextPosition) infoBoxInstance.setPosition(nextPosition);
+	}
+
+	$: if (infoBoxInstance && zIndex !== undefined) {
+		infoBoxInstance.setZIndex(zIndex);
+	}
+
+	$: listenerDeps = [
+		onCloseClick,
+		onDomReady,
+		onContentChanged,
+		onPositionChanged,
+		onZindexChanged
+	];
+
+	$: if (infoBoxInstance && googleMapsApi && browser && listenerDeps) {
+		setupListeners();
+	}
+
+	$: if (infoBoxInstance && map) {
+		openInfoBox();
+	}
+
+	onDestroy(() => {
+		if (infoBoxInstance) {
+			clearListeners();
+			onUnmount?.(infoBoxInstance);
+			infoBoxInstance.close();
+			infoBoxInstance = null;
+		}
+	});
+</script>
+
+<div bind:this={contentWrapper}>
+	<slot />
+</div>

--- a/packages/svelte-google-maps-api/src/lib/Marker.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Marker.svelte
@@ -2,6 +2,7 @@
 	import { getContext, onDestroy } from 'svelte';
 	import { BROWSER as browser } from 'esm-env';
 	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { ClusterableMarker, MarkerClustererContext } from './types/markerClusterer.js';
 
 	export let position: google.maps.LatLng | google.maps.LatLngLiteral;
 	export let options: google.maps.MarkerOptions = {};
@@ -53,15 +54,21 @@
 	let zindexChangedListener: google.maps.MapsEventListener | undefined = undefined;
 
 	let marker: google.maps.Marker | null = null;
+	let isClustered = false;
 	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
 	const map = getContext<google.maps.Map>('map');
+	const markerClusterer = getContext<MarkerClustererContext | undefined>('markerClusterer');
 
 	$: if ($status === 'loaded' && googleMapsApi && map && position && !marker) {
 		marker = new googleMapsApi.Marker({
 			position,
-			map: map,
+			...(markerClusterer ? {} : { map }),
 			...options
 		});
+		if (markerClusterer) {
+			markerClusterer.addMarker(marker as ClusterableMarker);
+			isClustered = true;
+		}
 		onLoad?.(marker);
 	}
 
@@ -70,9 +77,14 @@
 			if (googleMapsApi) {
 				googleMapsApi.event.clearInstanceListeners(marker);
 			}
-			marker.setMap(null);
+			if (isClustered && markerClusterer) {
+				markerClusterer.removeMarker(marker as ClusterableMarker);
+			} else {
+				marker.setMap(null);
+			}
 			onUnmount?.(marker);
 			marker = null;
+			isClustered = false;
 		}
 	});
 

--- a/packages/svelte-google-maps-api/src/lib/MarkerClusterer.svelte
+++ b/packages/svelte-google-maps-api/src/lib/MarkerClusterer.svelte
@@ -1,0 +1,109 @@
+<script context="module" lang="ts">
+	import type {
+		Cluster,
+		MarkerClustererOptions as BaseMarkerClustererOptions
+	} from '@googlemaps/markerclusterer';
+
+	export type MarkerClustererOptionsSubset = Omit<BaseMarkerClustererOptions, 'map' | 'markers'>;
+</script>
+
+<script lang="ts">
+	import { getContext, onDestroy, setContext } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import {
+		MarkerClusterer as GoogleMapsMarkerClusterer,
+		type Marker,
+		type MarkerClustererOptions
+	} from '@googlemaps/markerclusterer';
+	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { MarkerClustererContext } from './types/markerClusterer.js';
+
+	export let options: MarkerClustererOptionsSubset = {};
+	export let markers: Marker[] = [];
+	export let onClick: ((cluster: Cluster) => void) | undefined = undefined;
+	export let onClusterClick: MarkerClustererOptions['onClusterClick'] | undefined = undefined;
+	export let onLoad: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+	export let onUnmount: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+
+	let markerClusterer: GoogleMapsMarkerClusterer | null = null;
+	let registeredMarkers = new Set<Marker>();
+
+	const { status } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	function getOnClusterClick(): MarkerClustererOptions['onClusterClick'] | undefined {
+		if (onClusterClick) return onClusterClick;
+		if (!onClick) return undefined;
+
+		return ((event: google.maps.MapMouseEvent, cluster: Cluster) => {
+			onClick?.(cluster);
+		}) as MarkerClustererOptions['onClusterClick'];
+	}
+
+	function getClustererOptions(): MarkerClustererOptions {
+		const clusterClick = getOnClusterClick();
+
+		return {
+			...options,
+			map,
+			...(clusterClick ? { onClusterClick: clusterClick } : {})
+		};
+	}
+
+	function addMarker(marker: Marker) {
+		if (!markerClusterer || registeredMarkers.has(marker)) return;
+		registeredMarkers.add(marker);
+		markerClusterer.addMarker(marker, true);
+		markerClusterer.render();
+	}
+
+	function removeMarker(marker: Marker) {
+		if (!markerClusterer || !registeredMarkers.has(marker)) return;
+		markerClusterer.removeMarker(marker, true);
+		registeredMarkers.delete(marker);
+		markerClusterer.render();
+	}
+
+	setContext<MarkerClustererContext>('markerClusterer', {
+		addMarker,
+		removeMarker
+	});
+
+	function syncMarkers(nextMarkers: Marker[]) {
+		if (!markerClusterer) return;
+
+		for (const marker of Array.from(registeredMarkers)) {
+			if (!nextMarkers.includes(marker)) {
+				removeMarker(marker);
+			}
+		}
+
+		nextMarkers.forEach(addMarker);
+	}
+
+	$: if ($status === 'loaded' && map && !markerClusterer && browser) {
+		markerClusterer = new GoogleMapsMarkerClusterer(getClustererOptions());
+		syncMarkers(markers);
+		onLoad?.(markerClusterer);
+	}
+
+	$: if (markerClusterer && markers) {
+		syncMarkers(markers);
+	}
+
+	onDestroy(() => {
+		if (markerClusterer) {
+			onUnmount?.(markerClusterer);
+			markerClusterer.clearMarkers(true);
+			markerClusterer.setMap(null);
+			registeredMarkers.clear();
+			markerClusterer = null;
+		}
+	});
+</script>
+
+{#if markerClusterer}
+	<slot {markerClusterer} />
+{/if}

--- a/packages/svelte-google-maps-api/src/lib/Polygon.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Polygon.svelte
@@ -102,22 +102,21 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(polygonInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/Polyline.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Polyline.svelte
@@ -94,22 +94,21 @@
 			googleMapsApi.event.removeListener(pathUpdateListener);
 			pathUpdateListener = null;
 		}
-		const eventMap = {
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(polylineInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/Rectangle.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Rectangle.svelte
@@ -95,23 +95,22 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onBoundsChanged: 'bounds_changed',
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['bounds_changed', onBoundsChanged],
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(rectangleInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/index.ts
+++ b/packages/svelte-google-maps-api/src/lib/index.ts
@@ -10,14 +10,29 @@ import Rectangle from './Rectangle.svelte';
 import HeatmapLayer from './HeatmapLayer.svelte';
 import GroundOverlay from './GroundOverlay.svelte';
 import DirectionsRenderer from './DirectionsRenderer.svelte';
+import DirectionsService from './DirectionsService.svelte';
+import DistanceMatrixService from './DistanceMatrixService.svelte';
+import DrawingManager from './DrawingManager.svelte';
+import Data from './Data.svelte';
+import MarkerClusterer from './MarkerClusterer.svelte';
+import GoogleMarkerClusterer from './GoogleMarkerClusterer.svelte';
+import InfoBox from './InfoBox.svelte';
 import TrafficLayer from './layers/TrafficLayer.svelte';
 import TransitLayer from './layers/TransitLayer.svelte';
 import BicyclingLayer from './layers/BicyclingLayer.svelte';
 import KmlLayer from './layers/KmlLayer.svelte';
 import Autocomplete from './places/Autocomplete.svelte';
+import StandaloneSearchBox from './places/StandaloneSearchBox.svelte';
 import OverlayView from './overlay/OverlayView.svelte';
 import StreetViewPanorama from './street-view/StreetViewPanorama.svelte';
+import StreetViewService from './street-view/StreetViewService.svelte';
 import MapControl from './controls/MapControl.svelte';
+
+const FLOAT_PANE = 'floatPane';
+const MAP_PANE = 'mapPane';
+const MARKER_LAYER = 'markerLayer';
+const OVERLAY_LAYER = 'overlayLayer';
+const OVERLAY_MOUSE_TARGET = 'overlayMouseTarget';
 
 export {
 	APIProvider,
@@ -29,17 +44,33 @@ export {
 	Polygon,
 	Circle,
 	Rectangle,
+	Data,
 	HeatmapLayer,
 	GroundOverlay,
 	DirectionsRenderer,
+	DirectionsService,
+	DistanceMatrixService,
+	DrawingManager,
+	MarkerClusterer,
+	GoogleMarkerClusterer,
+	InfoBox,
 	TrafficLayer,
 	TransitLayer,
 	BicyclingLayer,
 	KmlLayer,
 	Autocomplete,
+	StandaloneSearchBox,
 	OverlayView,
 	StreetViewPanorama,
-	MapControl
+	StreetViewService,
+	MapControl,
+	FLOAT_PANE,
+	MAP_PANE,
+	MARKER_LAYER,
+	OVERLAY_LAYER,
+	OVERLAY_MOUSE_TARGET
 };
 
 export * from './types/googleMap.js';
+export * from './types/markerClusterer.js';
+export * as GoogleMapsMarkerClusterer from '@googlemaps/markerclusterer';

--- a/packages/svelte-google-maps-api/src/lib/layers/KmlLayer.svelte
+++ b/packages/svelte-google-maps-api/src/lib/layers/KmlLayer.svelte
@@ -63,6 +63,7 @@
 		layerInstance = null;
 	}
 	$: if (layerInstance && options) {
+		layerInstance.setOptions(options);
 	}
 
 	function setupListeners() {
@@ -71,14 +72,13 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onClick: 'click',
-			onDefaultViewportChanged: 'defaultviewport_changed',
-			onStatusChanged: 'status_changed'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['defaultviewport_changed', onDefaultViewportChanged],
+			['status_changed', onStatusChanged]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(layerInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/places/Autocomplete.svelte
+++ b/packages/svelte-google-maps-api/src/lib/places/Autocomplete.svelte
@@ -10,6 +10,7 @@
 	export let placeholder: string | undefined = undefined;
 	export let inputId: string | undefined = undefined;
 	export let inputClass: string = '';
+	export let className: string = '';
 	export let inputStyle: string = '';
 	export let disabled: boolean = false;
 
@@ -17,11 +18,13 @@
 		undefined;
 	export let componentRestrictions: google.maps.places.ComponentRestrictions | undefined =
 		undefined;
+	export let restrictions: google.maps.places.ComponentRestrictions | undefined = undefined;
 	export let fields: string[] | undefined = undefined;
 	export let strictBounds: boolean | undefined = undefined;
 	export let types: string[] | undefined = undefined;
 
 	const dispatch = createEventDispatcher<{ place_changed: google.maps.places.PlaceResult }>();
+	export let onPlaceChanged: (() => void) | undefined = undefined;
 	export let onLoad: ((autocomplete: google.maps.places.Autocomplete) => void) | undefined =
 		undefined;
 	export let onUnmount: ((autocomplete: google.maps.places.Autocomplete) => void) | undefined =
@@ -80,7 +83,7 @@
 		const autocompleteOptions: google.maps.places.AutocompleteOptions = {
 			...(options ?? {}),
 			bounds,
-			componentRestrictions,
+			componentRestrictions: componentRestrictions ?? restrictions,
 			fields,
 			strictBounds,
 			types
@@ -109,8 +112,8 @@
 	} else if (autocompleteInstance) {
 		const individualOptions: google.maps.places.AutocompleteOptions = {};
 		if (bounds !== undefined) individualOptions.bounds = bounds;
-		if (componentRestrictions !== undefined)
-			individualOptions.componentRestrictions = componentRestrictions;
+		if (componentRestrictions !== undefined || restrictions !== undefined)
+			individualOptions.componentRestrictions = componentRestrictions ?? restrictions;
 		if (fields !== undefined) individualOptions.fields = fields;
 		if (strictBounds !== undefined) individualOptions.strictBounds = strictBounds;
 		if (types !== undefined) individualOptions.types = types;
@@ -131,6 +134,7 @@
 				if (inputElement && place.name) {
 					value = place.name;
 				}
+				onPlaceChanged?.();
 				dispatch('place_changed', place);
 			}
 		});
@@ -169,6 +173,6 @@
 	{placeholder}
 	{disabled}
 	id={inputId}
-	class="svelte-google-maps-autocomplete {inputClass}"
+	class="svelte-google-maps-autocomplete {inputClass} {className}"
 	style={inputStyle}
 />

--- a/packages/svelte-google-maps-api/src/lib/places/StandaloneSearchBox.svelte
+++ b/packages/svelte-google-maps-api/src/lib/places/StandaloneSearchBox.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { createEventDispatcher, getContext, onDestroy, onMount, tick } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from '../APIProvider.svelte';
+
+	export let bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral | undefined =
+		undefined;
+	export let options: google.maps.places.SearchBoxOptions | undefined = undefined;
+
+	export let value: string = '';
+	export let placeholder: string | undefined = undefined;
+	export let inputId: string | undefined = undefined;
+	export let inputClass: string = '';
+	export let inputStyle: string = '';
+	export let disabled: boolean = false;
+
+	export let onPlacesChanged: ((places: google.maps.places.PlaceResult[] | undefined) => void) | undefined =
+		undefined;
+	export let onLoad: ((searchBox: google.maps.places.SearchBox) => void) | undefined = undefined;
+	export let onUnmount: ((searchBox: google.maps.places.SearchBox) => void) | undefined =
+		undefined;
+
+	const dispatch = createEventDispatcher<{
+		places_changed: google.maps.places.PlaceResult[] | undefined;
+	}>();
+
+	let containerElement: HTMLDivElement | null = null;
+	let inputElement: HTMLInputElement | null = null;
+	let searchBoxInstance: google.maps.places.SearchBox | null = null;
+	let placesChangedListener: google.maps.MapsEventListener | null = null;
+	let isMounted = false;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	onMount(() => {
+		isMounted = true;
+		tick().then(initializeSearchBox);
+	});
+
+	function getInputElement() {
+		return inputElement ?? containerElement?.querySelector('input') ?? null;
+	}
+
+	function initializeSearchBox() {
+		if (!browser || $status !== 'loaded' || !googleMapsApi || searchBoxInstance || !isMounted) {
+			return;
+		}
+
+		if (!googleMapsApi.places || !googleMapsApi.places.SearchBox) {
+			console.error(
+				'svelte-google-maps-api: StandaloneSearchBox requires the "places" library. Please include "places" in the libraries prop of APIProvider.'
+			);
+			return;
+		}
+
+		const input = getInputElement();
+		if (!input) return;
+
+		searchBoxInstance = new googleMapsApi.places.SearchBox(input, options);
+
+		if (bounds !== undefined) {
+			searchBoxInstance.setBounds(bounds);
+		}
+
+		setupListeners();
+		onLoad?.(searchBoxInstance);
+	}
+
+	function setupListeners() {
+		if (!searchBoxInstance || !googleMapsApi) return;
+
+		if (placesChangedListener) {
+			googleMapsApi.event.removeListener(placesChangedListener);
+			placesChangedListener = null;
+		}
+
+		placesChangedListener = searchBoxInstance.addListener('places_changed', () => {
+			const places = searchBoxInstance?.getPlaces();
+			onPlacesChanged?.(places);
+			dispatch('places_changed', places);
+		});
+	}
+
+	$: if ($status === 'loaded' && !searchBoxInstance) {
+		tick().then(initializeSearchBox);
+	}
+
+	$: if (searchBoxInstance && bounds !== undefined) {
+		searchBoxInstance.setBounds(bounds);
+	}
+
+	$: if (searchBoxInstance && googleMapsApi && browser && onPlacesChanged) {
+		setupListeners();
+	}
+
+	onDestroy(() => {
+		if (searchBoxInstance && googleMapsApi) {
+			onUnmount?.(searchBoxInstance);
+			if (placesChangedListener) {
+				googleMapsApi.event.removeListener(placesChangedListener);
+			}
+			googleMapsApi.event.clearInstanceListeners(searchBoxInstance);
+			searchBoxInstance = null;
+		}
+	});
+</script>
+
+<div bind:this={containerElement} class="svelte-google-maps-search-box">
+	{#if $$slots.default}
+		<slot />
+	{:else}
+		<input
+			bind:this={inputElement}
+			bind:value
+			{placeholder}
+			{disabled}
+			id={inputId}
+			class="svelte-google-maps-search-box-input {inputClass}"
+			style={inputStyle}
+		/>
+	{/if}
+</div>

--- a/packages/svelte-google-maps-api/src/lib/street-view/StreetViewPanorama.svelte
+++ b/packages/svelte-google-maps-api/src/lib/street-view/StreetViewPanorama.svelte
@@ -134,19 +134,18 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onCloseClick: 'closeclick',
-			onPanoChanged: 'pano_changed',
-			onPositionChanged: 'position_changed',
-			onPovChanged: 'pov_changed',
-			onResize: 'resize',
-			onStatusChanged: 'status_changed',
-			onVisibleChanged: 'visible_changed',
-			onZoomChanged: 'zoom_changed'
-		};
+		const eventHandlers = [
+			['closeclick', onCloseClick],
+			['pano_changed', onPanoChanged],
+			['position_changed', onPositionChanged],
+			['pov_changed', onPovChanged],
+			['resize', onResize],
+			['status_changed', onStatusChanged],
+			['visible_changed', onVisibleChanged],
+			['zoom_changed', onZoomChanged]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(panoramaInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/street-view/StreetViewService.svelte
+++ b/packages/svelte-google-maps-api/src/lib/street-view/StreetViewService.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from '../APIProvider.svelte';
+
+	export let onLoad: ((streetViewService: google.maps.StreetViewService) => void) | undefined =
+		undefined;
+	export let onUnmount: ((streetViewService: google.maps.StreetViewService) => void) | undefined =
+		undefined;
+
+	let streetViewService: google.maps.StreetViewService | null = null;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	$: if ($status === 'loaded' && googleMapsApi && !streetViewService && browser) {
+		streetViewService = new googleMapsApi.StreetViewService();
+		onLoad?.(streetViewService);
+	}
+
+	onDestroy(() => {
+		if (streetViewService) {
+			onUnmount?.(streetViewService);
+			streetViewService = null;
+		}
+	});
+</script>

--- a/packages/svelte-google-maps-api/src/lib/types/googleMap.ts
+++ b/packages/svelte-google-maps-api/src/lib/types/googleMap.ts
@@ -7,3 +7,5 @@ export type Library =
 	| 'places'
 	| 'routes'
 	| 'visualization';
+
+export type Libraries = Library[];

--- a/packages/svelte-google-maps-api/src/lib/types/markerClusterer.ts
+++ b/packages/svelte-google-maps-api/src/lib/types/markerClusterer.ts
@@ -1,0 +1,8 @@
+import type { Marker } from '@googlemaps/markerclusterer';
+
+export interface MarkerClustererContext {
+	addMarker: (marker: Marker) => void;
+	removeMarker: (marker: Marker) => void;
+}
+
+export type ClusterableMarker = Marker;

--- a/packages/svelte-google-maps-api/src/lib/utils/preventGoogleFonts.ts
+++ b/packages/svelte-google-maps-api/src/lib/utils/preventGoogleFonts.ts
@@ -1,0 +1,60 @@
+function isGoogleFontStyle(element: Node): boolean {
+	const href = (element as HTMLLinkElement).href;
+
+	if (
+		href &&
+		(href.indexOf('https://fonts.googleapis.com/css?family=Roboto') === 0 ||
+			href.indexOf('https://fonts.googleapis.com/css?family=Google+Sans+Text') === 0)
+	) {
+		return true;
+	}
+
+	const tagName = (element as HTMLElement).tagName?.toLowerCase();
+	if (tagName !== 'style') return false;
+
+	const styleElement = element as HTMLStyleElement & {
+		styleSheet?: { cssText?: string };
+	};
+	const styleSheetText = styleElement.styleSheet?.cssText;
+
+	if (styleSheetText && styleSheetText.replace('\r\n', '').indexOf('.gm-style') === 0) {
+		styleElement.styleSheet!.cssText = '';
+		return true;
+	}
+
+	if (
+		styleElement.innerHTML &&
+		styleElement.innerHTML.replace('\r\n', '').indexOf('.gm-style') === 0
+	) {
+		styleElement.innerHTML = '';
+		return true;
+	}
+
+	return !styleElement.styleSheet && !styleElement.innerHTML;
+}
+
+export function preventGoogleFonts(): void {
+	const head = document.getElementsByTagName('head')[0];
+	if (!head) return;
+
+	const trueInsertBefore = head.insertBefore.bind(head);
+	head.insertBefore = function insertBefore<T extends Node>(
+		newElement: T,
+		referenceElement: Node | null
+	): T {
+		if (!isGoogleFontStyle(newElement)) {
+			Reflect.apply(trueInsertBefore, head, [newElement, referenceElement]);
+		}
+
+		return newElement;
+	};
+
+	const trueAppend = head.appendChild.bind(head);
+	head.appendChild = function appendChild<T extends Node>(newElement: T): T {
+		if (!isGoogleFontStyle(newElement)) {
+			Reflect.apply(trueAppend, head, [newElement]);
+		}
+
+		return newElement;
+	};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.2.4
         version: 5.2.7(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@types/google.maps':
+        specifier: ^3.58.1
+        version: 3.58.1
       eslint:
         specifier: ^9.18.0
         version: 9.26.0(jiti@1.21.7)
@@ -143,8 +146,39 @@ importers:
         specifier: ^3.0.0
         version: 3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
+  apps/storybook:
+    dependencies:
+      svelte-google-maps-api:
+        specifier: workspace:*
+        version: link:../../packages/svelte-google-maps-api
+    devDependencies:
+      '@storybook/svelte':
+        specifier: ^8.6.14
+        version: 8.6.18(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)
+      '@storybook/svelte-vite':
+        specifier: ^8.6.14
+        version: 8.6.18(@babel/core@7.27.1)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.3
+        version: 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      storybook:
+        specifier: ^8.6.14
+        version: 8.6.18(prettier@3.5.3)
+      svelte:
+        specifier: ^5.28.2
+        version: 5.28.2
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
   packages/svelte-google-maps-api:
     dependencies:
+      '@googlemaps/markerclusterer':
+        specifier: ^2.6.2
+        version: 2.6.2
       esm-env:
         specifier: ^1.0.0
         version: 1.2.2
@@ -1281,6 +1315,10 @@ packages:
     resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/eslintrc@1.4.1':
+    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1314,6 +1352,9 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@googlemaps/markerclusterer@2.6.2':
+    resolution: {integrity: sha512-U6uVhq8iWhiIckA89sgRu8OK35mjd6/3CuoZKWakKEf0QmRRWpatlsPb3kqXkoWSmbcZkopRiI4dnW6DQSd7bQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1327,9 +1368,18 @@ packages:
     engines: {node: '>=10.10.0'}
     deprecated: Use @eslint/config-array instead
 
+  '@humanwhocodes/config-array@0.9.5':
+    resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@1.2.1':
+    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
@@ -1577,6 +1627,67 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@storybook/builder-vite@8.6.18':
+    resolution: {integrity: sha512-XLqnOv4C36jlTd4uC8xpWBxv+7GV4/05zWJ0wAcU4qflorropUTirt4UQPGkwIzi+BVAhs9pJj+m4k0IWJtpHg==}
+    peerDependencies:
+      storybook: ^8.6.18
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@storybook/components@8.6.18':
+    resolution: {integrity: sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/core@8.6.18':
+    resolution: {integrity: sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==}
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
+  '@storybook/csf-plugin@8.6.18':
+    resolution: {integrity: sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/csf@0.1.12':
+    resolution: {integrity: sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==}
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/manager-api@8.6.18':
+    resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/preview-api@8.6.18':
+    resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/svelte-vite@8.6.18':
+    resolution: {integrity: sha512-iKhtHWtgZ7LCB0qn9Rjwngnn9dZWqFLAQfWnbrMvnpWF83xKyDp+baoifKiQm7nasf/XtC3wLpN/BKoEGTMEQQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      storybook: ^8.6.18
+      svelte: ^4.0.0 || ^5.0.0
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@storybook/svelte@8.6.18':
+    resolution: {integrity: sha512-r6Go7UwW+Go6BZSL+tVUjQDUBCZxR/85iJRgNvIXKJi3QLFNBGwHMh5TcptsTWt5qypw8QXTNUd3siHCQGcswg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      storybook: ^8.6.18
+      svelte: ^4.0.0 || ^5.0.0
+
+  '@storybook/theming@8.6.18':
+    resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
@@ -1707,6 +1818,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/google.maps@3.58.1':
     resolution: {integrity: sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==}
 
@@ -1733,6 +1847,9 @@ packages:
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2032,6 +2149,10 @@ packages:
     resolution: {integrity: sha512-CkaUygzZ91Xbw11s0CsHMawrK3tl+Ue57725HGRgRzKgt2Z4wvXVXRCtQfvzh8K7Tp4Zp7f1pyHAtMROtTJHxg==}
     engines: {node: '>= 14.0.0'}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2077,6 +2198,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -2117,6 +2242,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  better-opn@3.0.2:
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -2134,6 +2263,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browser-assert@1.2.1:
+    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
 
   browserslist@4.24.5:
     resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
@@ -2386,6 +2518,10 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
@@ -2436,6 +2572,23 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@1.4.1:
+    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@3.3.0:
+    resolution: {integrity: sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==}
+    engines: {node: '>= 4'}
+
+  domhandler@4.3.1:
+    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
+    engines: {node: '>= 4'}
+
+  domutils@2.8.0:
+    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2466,6 +2619,13 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+
+  entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
   entities@6.0.0:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
@@ -2503,6 +2663,11 @@ packages:
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2584,6 +2749,16 @@ packages:
     resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-utils@3.0.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+
+  eslint-visitor-keys@2.1.0:
+    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
+    engines: {node: '>=10'}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2591,6 +2766,12 @@ packages:
   eslint-visitor-keys@4.2.0:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@8.4.1:
+    resolution: {integrity: sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -2615,9 +2796,18 @@ packages:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  espree@9.2.0:
+    resolution: {integrity: sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
@@ -2685,6 +2875,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2786,6 +2980,9 @@ packages:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -2824,12 +3021,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -2913,6 +3110,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2-svelte@4.1.0:
+    resolution: {integrity: sha512-+4f4RBFz7Rj2Hp0ZbFbXC+Kzbd6S9PgjiuFtdT76VMNgKogrEZy0pG2UrPycPbrZzVEIM5lAT3lAdkSTCHLPjg==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -2935,6 +3135,10 @@ packages:
   ignore-walk@5.0.1:
     resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  ignore@4.0.6:
+    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
+    engines: {node: '>= 4'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2979,6 +3183,10 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -3017,6 +3225,11 @@ packages:
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -3127,6 +3340,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
@@ -3156,6 +3373,10 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@4.8.0:
+    resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
+    engines: {node: '>=12.0.0'}
 
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
@@ -3202,6 +3423,9 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3570,6 +3794,10 @@ packages:
     resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
     engines: {node: '>=18'}
 
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3761,6 +3989,14 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
 
@@ -3812,6 +4048,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3839,6 +4079,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  regexpp@3.2.0:
+    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
+    engines: {node: '>=8'}
 
   regexpu-core@6.2.0:
     resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
@@ -4075,6 +4319,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -4092,6 +4337,15 @@ packages:
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  storybook@8.6.18:
+    resolution: {integrity: sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -4134,6 +4388,9 @@ packages:
 
   strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4222,6 +4479,10 @@ packages:
     resolution: {integrity: sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==}
     engines: {node: '>=18'}
 
+  sveltedoc-parser@4.2.1:
+    resolution: {integrity: sha512-sWJRa4qOfRdSORSVw9GhfDEwsbsYsegnDzBevUCF6k/Eis/QqCu9lJ6I0+d/E2wOWCjOhlcJ3+jl/Iur+5mmCw==}
+    engines: {node: '>=10.0.0'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4240,6 +4501,9 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4312,6 +4576,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -4387,6 +4655,10 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -4499,6 +4771,10 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
+
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -4514,6 +4790,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  v8-compile-cache@2.4.0:
+    resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -4733,6 +5015,9 @@ packages:
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -5974,6 +6259,20 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/eslintrc@1.4.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
@@ -6024,6 +6323,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@googlemaps/markerclusterer@2.6.2':
+    dependencies:
+      '@types/supercluster': 7.1.3
+      fast-equals: 5.4.0
+      supercluster: 8.0.1
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -6039,7 +6344,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@humanwhocodes/config-array@0.9.5':
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.4.0
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@1.2.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
@@ -6274,6 +6589,104 @@ snapshots:
   '@sinclair/typebox@0.27.8': {}
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      browser-assert: 1.2.1
+      storybook: 8.6.18(prettier@3.5.3)
+      ts-dedent: 2.2.0
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
+  '@storybook/components@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+
+  '@storybook/core@8.6.18(prettier@3.5.3)(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      better-opn: 3.0.2
+      browser-assert: 1.2.1
+      esbuild: 0.25.3
+      esbuild-register: 3.6.0(esbuild@0.25.3)
+      jsdoc-type-pratt-parser: 4.8.0
+      process: 0.11.10
+      recast: 0.23.11
+      semver: 7.7.1
+      util: 0.12.5
+      ws: 8.18.2
+    optionalDependencies:
+      prettier: 3.5.3
+    transitivePeerDependencies:
+      - bufferutil
+      - storybook
+      - supports-color
+      - utf-8-validate
+
+  '@storybook/csf-plugin@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+      unplugin: 1.16.1
+
+  '@storybook/csf@0.1.12':
+    dependencies:
+      type-fest: 2.19.0
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/manager-api@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+
+  '@storybook/preview-api@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+
+  '@storybook/svelte-vite@8.6.18(@babel/core@7.27.1)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@storybook/svelte': 8.6.18(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      magic-string: 0.30.17
+      storybook: 8.6.18(prettier@3.5.3)
+      svelte: 5.28.2
+      svelte-preprocess: 5.1.4(@babel/core@7.27.1)(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(svelte@5.28.2)(typescript@5.8.3)
+      svelte2tsx: 0.7.37(svelte@5.28.2)(typescript@5.8.3)
+      sveltedoc-parser: 4.2.1
+      ts-dedent: 2.2.0
+      typescript: 5.8.3
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+
+  '@storybook/svelte@8.6.18(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)':
+    dependencies:
+      '@storybook/components': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/csf': 0.1.12
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/preview-api': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      storybook: 8.6.18(prettier@3.5.3)
+      svelte: 5.28.2
+      sveltedoc-parser: 4.2.1
+      ts-dedent: 2.2.0
+      type-fest: 2.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@storybook/theming@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -6514,6 +6927,8 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/google.maps@3.58.1': {}
 
   '@types/hast@3.0.4':
@@ -6537,6 +6952,10 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@types/semver@7.7.0': {}
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/trusted-types@2.0.7': {}
 
@@ -6998,6 +7417,8 @@ snapshots:
       '@algolia/requester-fetch': 5.24.0
       '@algolia/requester-node-http': 5.24.0
 
+  ansi-colors@4.1.3: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -7040,6 +7461,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   async-function@1.0.0: {}
 
   async@3.2.6: {}
@@ -7080,6 +7505,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
+
   binary-extensions@2.3.0: {}
 
   body-parser@2.2.0:
@@ -7108,6 +7537,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-assert@1.2.1: {}
 
   browserslist@4.24.5:
     dependencies:
@@ -7343,6 +7774,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  define-lazy-prop@2.0.0: {}
+
   define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
@@ -7381,6 +7814,28 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@1.4.1:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      entities: 2.2.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@3.3.0:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domhandler@4.3.1:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@2.8.0:
+    dependencies:
+      dom-serializer: 1.4.1
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7404,6 +7859,13 @@ snapshots:
   emoticon@4.1.0: {}
 
   encodeurl@2.0.0: {}
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
+
+  entities@2.2.0: {}
 
   entities@6.0.0: {}
 
@@ -7487,6 +7949,13 @@ snapshots:
       is-symbol: 1.1.1
 
   es6-promise@3.3.1: {}
+
+  esbuild-register@3.6.0(esbuild@0.25.3):
+    dependencies:
+      debug: 4.4.0
+      esbuild: 0.25.3
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -7639,9 +8108,59 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-utils@3.0.0(eslint@8.4.1):
+    dependencies:
+      eslint: 8.4.1
+      eslint-visitor-keys: 2.1.0
+
+  eslint-visitor-keys@2.1.0: {}
+
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.0: {}
+
+  eslint@8.4.1:
+    dependencies:
+      '@eslint/eslintrc': 1.4.1
+      '@humanwhocodes/config-array': 0.9.5
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0
+      doctrine: 3.0.0
+      enquirer: 2.4.1
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-utils: 3.0.0(eslint@8.4.1)
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      ignore: 4.0.6
+      import-fresh: 3.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      progress: 2.0.3
+      regexpp: 3.2.0
+      semver: 7.7.1
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+      v8-compile-cache: 2.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@8.57.1:
     dependencies:
@@ -7738,11 +8257,19 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 4.2.0
 
+  espree@9.2.0:
+    dependencies:
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
+      eslint-visitor-keys: 3.4.3
+
   espree@9.6.1:
     dependencies:
       acorn: 8.14.1
       acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 3.4.3
+
+  esprima@4.0.1: {}
 
   esquery@1.6.0:
     dependencies:
@@ -7821,6 +8348,8 @@ snapshots:
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -7931,6 +8460,8 @@ snapshots:
       functions-have-names: 1.2.3
       hasown: 2.0.2
       is-callable: 1.2.7
+
+  functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
 
@@ -8075,6 +8606,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2-svelte@4.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 3.3.0
+      domutils: 2.8.0
+      entities: 2.2.0
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -8106,6 +8644,8 @@ snapshots:
   ignore-walk@5.0.1:
     dependencies:
       minimatch: 5.1.6
+
+  ignore@4.0.6: {}
 
   ignore@5.3.2: {}
 
@@ -8154,6 +8694,11 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -8199,6 +8744,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
+
+  is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
 
@@ -8293,6 +8840,10 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
@@ -8317,6 +8868,8 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@4.8.0: {}
 
   jsdom@26.1.0:
     dependencies:
@@ -8368,6 +8921,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonpointer@5.0.1: {}
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -8926,6 +9481,12 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -9095,6 +9656,10 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process@0.11.10: {}
+
+  progress@2.0.3: {}
+
   property-information@7.0.0: {}
 
   proxy-addr@2.0.7:
@@ -9141,6 +9706,14 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -9182,6 +9755,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  regexpp@3.2.0: {}
 
   regexpu-core@6.2.0:
     dependencies:
@@ -9536,6 +10111,16 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  storybook@8.6.18(prettier@3.5.3):
+    dependencies:
+      '@storybook/core': 8.6.18(prettier@3.5.3)(storybook@8.6.18(prettier@3.5.3))
+    optionalDependencies:
+      prettier: 3.5.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -9601,6 +10186,10 @@ snapshots:
   strip-literal@1.3.0:
     dependencies:
       acorn: 8.14.1
+
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.1.0
 
   supports-color@7.2.0:
     dependencies:
@@ -9699,6 +10288,14 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
+  sveltedoc-parser@4.2.1:
+    dependencies:
+      eslint: 8.4.1
+      espree: 9.2.0
+      htmlparser2-svelte: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   symbol-tree@3.2.4: {}
 
   temp-dir@2.0.0: {}
@@ -9718,6 +10315,8 @@ snapshots:
       source-map-support: 0.5.21
 
   text-table@0.2.0: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -9771,6 +10370,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-dedent@2.2.0: {}
 
   tslib@1.14.1: {}
 
@@ -9834,6 +10435,8 @@ snapshots:
   type-fest@0.16.0: {}
 
   type-fest@0.20.2: {}
+
+  type-fest@2.19.0: {}
 
   type-is@2.0.1:
     dependencies:
@@ -9992,6 +10595,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.14.1
+      webpack-virtual-modules: 0.6.2
+
   upath@1.2.0: {}
 
   update-browserslist-db@1.1.3(browserslist@4.24.5):
@@ -10005,6 +10613,16 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.0
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.19
+
+  v8-compile-cache@2.4.0: {}
 
   vary@1.1.2: {}
 
@@ -10213,6 +10831,8 @@ snapshots:
   webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-encoding@3.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Add missing Google Maps components for data layers, service wrappers, search boxes, custom info overlays, and marker clustering.
- Expand provider and component APIs, including clusterer integration and additional event wiring.
- Add synchronized component docs, navigation entries, and Storybook stories for every component.

## Validation

- `corepack pnpm check`
- `corepack pnpm lint` (passes with existing warnings, no errors)
- `corepack pnpm test`
- `HOME=/private/tmp/storybook-home STORYBOOK_DISABLE_TELEMETRY=1 corepack pnpm build`