### PR TITLE
Update component docs deployment

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,6 +18,10 @@ module.exports = {
 		es2017: true,
 		node: true
 	},
+	rules: {
+		'no-undef': 'off',
+		'@typescript-eslint/no-inferrable-types': 'off'
+	},
 	overrides: [
 		{
 			files: ['*.svelte'],

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'apps/docs/**'
+      - 'apps/storybook/**'
       - 'packages/svelte-google-maps-api/**'
       - '.github/workflows/deploy-docs.yml'
       - 'pnpm-lock.yaml'
@@ -46,6 +47,17 @@ jobs:
 
       - name: Build Docs
         run: pnpm build --filter=docs
+
+      - name: Build Storybook
+        run: pnpm build --filter=storybook
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: '1'
+
+      - name: Attach Storybook to Docs
+        run: |
+          rm -rf apps/docs/build/storybook
+          mkdir -p apps/docs/build/storybook
+          cp -R apps/storybook/storybook-static/. apps/docs/build/storybook/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 *.log
+
+apps/examples/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Svelte component library for Google Maps API integration, structured as a pnpm monorepo using Turborepo. The library provides 20+ components for declarative Google Maps usage in Svelte 5 applications.
+
+## Key Commands
+
+### Development
+```bash
+# Install dependencies
+pnpm install
+
+# Start development servers (library + docs)
+pnpm dev
+
+# Build everything
+pnpm build
+
+# Build only the library package
+pnpm package
+
+# Type checking
+pnpm check
+
+# Linting
+pnpm lint
+
+# Format code
+pnpm format
+
+# Run tests
+pnpm test
+```
+
+### Working on specific packages
+```bash
+# Library development
+cd packages/svelte-google-maps-api
+pnpm dev
+
+# Documentation site
+cd apps/docs
+pnpm dev
+
+# Examples
+cd apps/examples
+pnpm dev
+```
+
+## Architecture
+
+### Monorepo Structure
+- `/packages/svelte-google-maps-api/` - Main library with all Google Maps components
+- `/apps/docs/` - SveltePress documentation site
+- `/apps/examples/` - Example applications
+
+### Component Architecture
+All components follow a consistent pattern:
+1. Components use `getContext` to access the Google Maps API instance from `APIProvider`
+2. Each component manages its own Google Maps object lifecycle (create on mount, destroy on unmount)
+3. Props are reactive using `$effect` for Svelte 5 runes
+4. TypeScript types are imported from `@types/google.maps`
+
+### Key Components
+- `APIProvider.svelte` - Loads Google Maps API and provides context
+- `GoogleMap.svelte` - Main map container that provides map instance to children
+- All other components require being nested within `GoogleMap` (except `Autocomplete` and `StreetViewPanorama`)
+
+### Build Process
+1. Turborepo orchestrates builds across packages
+2. Library uses `svelte-package` for building
+3. `publint` validates package before publishing
+4. Documentation uses `@sveltejs/adapter-static` for static site generation
+
+## Testing Approach
+When adding new features or fixing bugs:
+1. Create or update the example in `/apps/examples/`
+2. Add component tests using Vitest
+3. Update documentation in `/apps/docs/src/routes/components/[component-name]/+page.md`
+4. Run `pnpm test` to ensure all tests pass
+
+## Code Style
+- TypeScript with strict mode
+- Prettier formatting (tabs, single quotes, no trailing commas)
+- ESLint for code quality
+- Svelte 5 with runes (`$state`, `$effect`, etc.)
+
+## PR作成時
+created By Claudeみたいな文言は不要です

--- a/apps/docs/src/routes/components/advanced-marker/+page.md
+++ b/apps/docs/src/routes/components/advanced-marker/+page.md
@@ -2,6 +2,10 @@
 title: AdvancedMarker
 ---
 
+## Storybook
+
+[Open the AdvancedMarker story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-advancedmarker--basic)
+
 The `AdvancedMarker` component creates and manages advanced markers on the map, allowing for custom HTML content.
 
 ## Props

--- a/apps/docs/src/routes/components/api-provider/+page.md
+++ b/apps/docs/src/routes/components/api-provider/+page.md
@@ -2,18 +2,34 @@
 title: APIProvider
 ---
 
+## Storybook
+
+[Open the APIProvider story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-apiprovider--basic)
+
 The `APIProvider` component is responsible for loading the Google Maps JavaScript API.
 
 ## Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| apiKey | string | | Google Maps API key (required) |
-| libraries | string[] | [] | Optional array of Google Maps libraries to load |
-| version | string | 'weekly' | Google Maps API version to load |
-| language | string | | Language for the Google Maps API |
-| region | string | | Region for the Google Maps API |
-| mapIds | string[] | [] | Map IDs for cloud-based map styling |
+| apiKey | `string` | `''` | Google Maps API key. |
+| googleMapsApiKey | `string` | | React-compatible API key alias. |
+| googleMapsClientId | `string` | | Google Maps Premium Plan client id. Do not use with an API key. |
+| libraries | `Library[]` | `[]` | Google Maps libraries to load. |
+| version | `string` | `'weekly'` | Google Maps API version to load. |
+| language | `string` | | Language for the Google Maps API. |
+| region | `string` | | Region for the Google Maps API. |
+| channel | `string` | | Usage tracking channel. |
+| mapIds | `string[]` | | Map IDs for cloud-based map styling. |
+| authReferrerPolicy | `'origin'` | | Auth referrer policy. |
+| apiUrl | `string` | `'https://maps.googleapis.com'` | Google Maps API base URL. |
+| solutionChannel | `string` | | Google solution channel. |
+| id | `string` | `'svelte-google-maps-api-script'` | Script element id. |
+| nonce | `string` | | CSP nonce for the script tag. |
+| preventGoogleFontsLoading | `boolean` | `false` | Prevents Google Maps from injecting its default font styles. |
+| onLoad | `() => void` | | Called when the script has loaded. |
+| onError | `(error: Error) => void` | | Called when the script fails to load. |
+| onUnmount | `() => void` | | Called when the provider is destroyed. |
 
 ## Usage
 
@@ -32,13 +48,7 @@ The `APIProvider` component is responsible for loading the Google Maps JavaScrip
 
 ## Context
 
-The `APIProvider` component sets a context that is consumed by child components:
-
-```javascript
-setContext('googleMap', { isReady });
-```
-
-This context is used by components like `GoogleMap` to know when the Google Maps API is loaded and ready to use.
+The `APIProvider` component sets the `svelte-google-maps-api` context with the load status, API reference, and error state. `GoogleMap` and service components use that context to wait for the script before creating Google Maps objects.
 
 ## Loading Multiple Libraries
 

--- a/apps/docs/src/routes/components/autocomplete/+page.md
+++ b/apps/docs/src/routes/components/autocomplete/+page.md
@@ -1,76 +1,55 @@
 ---
 title: Autocomplete
 ---
-The `Autocomplete` component provides a text input field that suggests geographic locations as the user types, leveraging the Google Places Autocomplete service.
 
-## Usage
+## Storybook
 
-First, ensure you load the `places` library via the `APIProvider`.
+[Open the Autocomplete story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-autocomplete--basic)
 
-```svelte
-<script lang="ts">
-  import { APIProvider, GoogleMap, Marker, Autocomplete } from 'svelte-google-maps-api';
-
-  let apiKey = 'YOUR_MAP_KEY'; // Replace with your API key
-  let map: google.maps.Map | null = null;
-  let selectedPlace: google.maps.places.PlaceResult | null = null;
-  let mapCenter = { lat: 35.681, lng: 139.767 }; // Default center (Tokyo)
-  let mapZoom = 12;
-
-  function handlePlaceChanged(event: CustomEvent<google.maps.places.PlaceResult>) {
-    const place = event.detail;
-    if (place.geometry?.location) {
-      selectedPlace = place;
-      // Update map center and zoom based on the selected place
-      mapCenter = place.geometry.location.toJSON();
-      mapZoom = 17;
-      console.log('Selected Place:', place.name, place.geometry.location.toJSON());
-    } else {
-      console.log('Returned place contains no geometry');
-    }
-  }
-</script>
-
-<div style="height: 500px; width: 100%; display: flex; flex-direction: column;">
-  <APIProvider {apiKey} libraries={['places']}>
-    <div style="padding: 10px;">
-      <Autocomplete
-        placeholder="Enter a location"
-        on:place_changed={handlePlaceChanged}
-        options={{
-          types: ['geocode'],
-          fields: ['name', 'geometry.location'] // Specify fields to reduce cost
-          // componentRestrictions: { country: 'jp' } // Example restriction
-        }}
-        style="width: 300px; padding: 8px; margin-bottom: 10px; font-size: 1rem;"
-      />
-    </div>
-
-    <div style="flex-grow: 1;">
-      <GoogleMap bind:map options={{ center: mapCenter, zoom: mapZoom, disableDefaultUI: true }}>
-        {#if selectedPlace && selectedPlace.geometry?.location}
-          <Marker position={selectedPlace.geometry.location} title={selectedPlace.name} />
-        {/if}
-      </GoogleMap>
-    </div>
-  </APIProvider>
-</div>
-```
+The `Autocomplete` component creates a Google Places autocomplete input.
 
 ## Props
 
-*(Specific props for the Svelte component need confirmation. Common ones include)*
-
-*   `options`: `google.maps.places.AutocompleteOptions` - Configuration for the Autocomplete service (e.g., types, fields, componentRestrictions).
-*   `placeholder`: `string` - Placeholder text for the input field.
-*   `style`: `string` - Inline styles for the input element.
-*   `class`: `string` - CSS classes for the input element.
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| options | `google.maps.places.AutocompleteOptions` | | Autocomplete options. |
+| value | `string` | `''` | Input value. |
+| placeholder | `string` | | Input placeholder. |
+| inputId | `string` | | Input id. |
+| inputClass | `string` | `''` | Input class. |
+| className | `string` | `''` | React-compatible class alias added to the input. |
+| inputStyle | `string` | `''` | Input inline style. |
+| disabled | `boolean` | `false` | Disables the input. |
+| bounds | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral` | | Result bias bounds. |
+| componentRestrictions | `google.maps.places.ComponentRestrictions` | | Component restrictions. |
+| restrictions | `google.maps.places.ComponentRestrictions` | | React-compatible alias for component restrictions. |
+| fields | `string[]` | | Place fields to return. |
+| strictBounds | `boolean` | | Restricts predictions to the bounds. |
+| types | `string[]` | | Place types. |
+| onPlaceChanged | `() => void` | | React-compatible place changed callback. |
+| onLoad | `(autocomplete: google.maps.places.Autocomplete) => void` | | Called after creation. |
+| onUnmount | `(autocomplete: google.maps.places.Autocomplete) => void` | | Called before teardown. |
 
 ## Events
 
-*   **`on:place_changed`**: Fired when a place is selected from the suggestions. The `event.detail` contains the `google.maps.places.PlaceResult`.
+The component dispatches `place_changed` with the selected `google.maps.places.PlaceResult`.
+
+## Usage
+
+```svelte
+<APIProvider apiKey="YOUR_API_KEY" libraries={['places']}>
+  <Autocomplete
+    placeholder="Enter a location"
+    fields={['name', 'geometry.location']}
+    inputStyle="width: 300px; padding: 8px;"
+    on:place_changed={(event) => {
+      selectedPlace = event.detail;
+    }}
+  />
+</APIProvider>
+```
 
 ## Notes
 
-*   Requires the `places` library to be loaded in `APIProvider`.
-*   Specify the `fields` option to request only the data you need, which can affect billing. See [Google Maps Platform documentation](https://developers.google.com/maps/documentation/javascript/places-autocomplete#specify-fields) for details. 
+- Requires `libraries={['places']}` on `APIProvider`.
+- Specify `fields` to request only the data you need.

--- a/apps/docs/src/routes/components/bicycling-layer/+page.md
+++ b/apps/docs/src/routes/components/bicycling-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: BicyclingLayer
 ---
+
+## Storybook
+
+[Open the BicyclingLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-bicyclinglayer--basic)
 The `BicyclingLayer` component displays bicycle paths, suggested routes, and other overlays specific to cycling on the map.
 
 ## Usage

--- a/apps/docs/src/routes/components/circle/+page.md
+++ b/apps/docs/src/routes/components/circle/+page.md
@@ -2,6 +2,10 @@
 title: Circle
 ---
 
+## Storybook
+
+[Open the Circle story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-circle--basic)
+
 The `Circle` component draws a circle on the map with a specified center and radius.
 
 ## Props

--- a/apps/docs/src/routes/components/data/+page.md
+++ b/apps/docs/src/routes/components/data/+page.md
@@ -1,0 +1,34 @@
+---
+title: Data
+---
+
+The `Data` component manages a `google.maps.Data` layer for GeoJSON features and feature-level events.
+
+## Storybook
+
+[Open the Data story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-data--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `google.maps.Data.DataOptions` | Initial Data layer options. `style`, `controls`, `controlPosition`, and `drawingMode` are also applied reactively. |
+| onLoad | `(data: google.maps.Data) => void` | Called after the Data layer is created. |
+| onUnmount | `(data: google.maps.Data) => void` | Called before the Data layer is removed. |
+
+## Events
+
+`onClick`, `onDblClick`, `onMouseDown`, `onMouseMove`, `onMouseOut`, `onMouseOver`, `onMouseUp`, `onRightClick`, `onAddFeature`, `onRemoveFeature`, `onRemoveProperty`, `onSetGeometry`, and `onSetProperty` map to the corresponding Google Maps Data events.
+
+## Usage
+
+```svelte
+<GoogleMap options={{ center, zoom: 12 }}>
+  <Data
+    onLoad={(data) => {
+      data.addGeoJson(geoJson);
+      data.setStyle({ fillColor: '#0f766e', strokeColor: '#0f766e' });
+    }}
+  />
+</GoogleMap>
+```

--- a/apps/docs/src/routes/components/directions-renderer/+page.md
+++ b/apps/docs/src/routes/components/directions-renderer/+page.md
@@ -1,0 +1,38 @@
+---
+title: DirectionsRenderer
+---
+
+The `DirectionsRenderer` component renders a `google.maps.DirectionsResult` on the current map.
+
+## Storybook
+
+[Open the DirectionsRenderer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-directionsrenderer--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| directions | `google.maps.DirectionsResult` | Directions result to render. |
+| options | `google.maps.DirectionsRendererOptions` | Renderer options. |
+| routeIndex | `number` | Route index to display. |
+| panel | `HTMLElement` | Optional directions panel element. |
+| draggable | `boolean` | Makes the rendered route draggable. |
+| hideRouteList | `boolean` | Hides the route list. |
+| preserveViewport | `boolean` | Keeps the current viewport. |
+| suppressMarkers | `boolean` | Suppresses default route markers. |
+| suppressInfoWindows | `boolean` | Suppresses default info windows. |
+| suppressPolylines | `boolean` | Suppresses default polylines. |
+| markerOptions | `google.maps.MarkerOptions` | Options for route markers. |
+| polylineOptions | `google.maps.PolylineOptions` | Options for route polylines. |
+| onDirectionsChanged | `() => void` | Called when renderer directions change. |
+| onLoad | `(renderer: google.maps.DirectionsRenderer) => void` | Called after creation. |
+| onUnmount | `(renderer: google.maps.DirectionsRenderer) => void` | Called before removal. |
+
+## Usage
+
+```svelte
+<DirectionsService options={request} callback={(result) => (directions = result ?? undefined)} />
+{#if directions}
+  <DirectionsRenderer {directions} />
+{/if}
+```

--- a/apps/docs/src/routes/components/directions-service/+page.md
+++ b/apps/docs/src/routes/components/directions-service/+page.md
@@ -1,0 +1,30 @@
+---
+title: DirectionsService
+---
+
+The `DirectionsService` component wraps `google.maps.DirectionsService` and calls `route` whenever `options` changes.
+
+## Storybook
+
+[Open the DirectionsService story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-directionsservice--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `google.maps.DirectionsRequest` | Route request. |
+| callback | `(result, status) => void` | Receives the route result and status. |
+| onLoad | `(service: google.maps.DirectionsService) => void` | Called after service creation. |
+| onUnmount | `(service: google.maps.DirectionsService) => void` | Called before teardown. |
+
+## Usage
+
+```svelte
+<DirectionsService
+  options={{ origin, destination, travelMode: 'DRIVING' }}
+  callback={(result, status) => {
+    directions = result ?? undefined;
+    console.log(status);
+  }}
+/>
+```

--- a/apps/docs/src/routes/components/distance-matrix-service/+page.md
+++ b/apps/docs/src/routes/components/distance-matrix-service/+page.md
@@ -1,0 +1,27 @@
+---
+title: DistanceMatrixService
+---
+
+The `DistanceMatrixService` component wraps `google.maps.DistanceMatrixService` and calls `getDistanceMatrix` whenever `options` changes.
+
+## Storybook
+
+[Open the DistanceMatrixService story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-distancematrixservice--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `google.maps.DistanceMatrixRequest` | Distance Matrix request. |
+| callback | `(response, status) => void` | Receives the response and status. |
+| onLoad | `(service: google.maps.DistanceMatrixService) => void` | Called after service creation. |
+| onUnmount | `(service: google.maps.DistanceMatrixService) => void` | Called before teardown. |
+
+## Usage
+
+```svelte
+<DistanceMatrixService
+  options={{ origins, destinations, travelMode: 'DRIVING' }}
+  callback={(response, status) => console.log(status, response)}
+/>
+```

--- a/apps/docs/src/routes/components/drawing-manager/+page.md
+++ b/apps/docs/src/routes/components/drawing-manager/+page.md
@@ -1,0 +1,158 @@
+# DrawingManager
+
+The `DrawingManager` component provides a graphical interface for users to draw overlays on the map, including markers, polylines, polygons, rectangles, and circles.
+
+## Basic Usage
+
+```svelte
+<script>
+  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
+</script>
+
+<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
+  <GoogleMap
+    zoom={12}
+    center={{ lat: 35.6812362, lng: 139.7649361 }}
+    options={{ mapTypeId: 'roadmap' }}
+  >
+    <DrawingManager
+      drawingControl={true}
+      drawingControlOptions={{
+        position: google.maps.ControlPosition.TOP_CENTER,
+        drawingModes: [
+          google.maps.drawing.OverlayType.MARKER,
+          google.maps.drawing.OverlayType.CIRCLE,
+          google.maps.drawing.OverlayType.POLYGON,
+          google.maps.drawing.OverlayType.POLYLINE,
+          google.maps.drawing.OverlayType.RECTANGLE
+        ]
+      }}
+    />
+  </GoogleMap>
+</APIProvider>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `drawingMode` | `google.maps.drawing.OverlayType \| null` | `null` | The current drawing mode |
+| `drawingControl` | `boolean` | `true` | Whether the drawing control UI is displayed |
+| `drawingControlOptions` | `google.maps.drawing.DrawingControlOptions` | `undefined` | Options for the drawing control |
+| `circleOptions` | `google.maps.CircleOptions` | `undefined` | Default options for circles |
+| `markerOptions` | `google.maps.MarkerOptions` | `undefined` | Default options for markers |
+| `polygonOptions` | `google.maps.PolygonOptions` | `undefined` | Default options for polygons |
+| `polylineOptions` | `google.maps.PolylineOptions` | `undefined` | Default options for polylines |
+| `rectangleOptions` | `google.maps.RectangleOptions` | `undefined` | Default options for rectangles |
+
+## Events
+
+| Event | Type | Description |
+|-------|------|-------------|
+| `onCircleComplete` | `(circle: google.maps.Circle) => void` | Called when a circle is completed |
+| `onMarkerComplete` | `(marker: google.maps.Marker) => void` | Called when a marker is completed |
+| `onOverlayComplete` | `(event: google.maps.drawing.OverlayCompleteEvent) => void` | Called when any overlay is completed |
+| `onPolygonComplete` | `(polygon: google.maps.Polygon) => void` | Called when a polygon is completed |
+| `onPolylineComplete` | `(polyline: google.maps.Polyline) => void` | Called when a polyline is completed |
+| `onRectangleComplete` | `(rectangle: google.maps.Rectangle) => void` | Called when a rectangle is completed |
+| `onDrawingModeChange` | `() => void` | Called when the drawing mode changes |
+| `onLoad` | `(drawingManager: google.maps.drawing.DrawingManager) => void` | Called when the DrawingManager is loaded |
+| `onUnmount` | `(drawingManager: google.maps.drawing.DrawingManager) => void` | Called when the DrawingManager is unmounted |
+
+## Example with Custom Styling
+
+```svelte
+<script>
+  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
+
+  let drawnShapes = [];
+
+  function handleOverlayComplete(event) {
+    drawnShapes.push(event.overlay);
+    // You can store the overlay for later manipulation
+    console.log('New shape drawn:', event.type);
+  }
+</script>
+
+<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
+  <GoogleMap
+    zoom={12}
+    center={{ lat: 35.6812362, lng: 139.7649361 }}
+    options={{ mapTypeId: 'roadmap' }}
+  >
+    <DrawingManager
+      drawingControl={true}
+      circleOptions={{
+        fillColor: '#ff0000',
+        fillOpacity: 0.35,
+        strokeWeight: 2,
+        clickable: true,
+        editable: true,
+        zIndex: 1
+      }}
+      polygonOptions={{
+        fillColor: '#00ff00',
+        fillOpacity: 0.35,
+        strokeWeight: 2,
+        clickable: true,
+        editable: true,
+        zIndex: 1
+      }}
+      rectangleOptions={{
+        fillColor: '#0000ff',
+        fillOpacity: 0.35,
+        strokeWeight: 2,
+        clickable: true,
+        editable: true,
+        zIndex: 1
+      }}
+      onOverlayComplete={handleOverlayComplete}
+    />
+  </GoogleMap>
+</APIProvider>
+```
+
+## Drawing Mode Control
+
+You can programmatically control the drawing mode:
+
+```svelte
+<script>
+  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
+
+  let drawingMode = null;
+</script>
+
+<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
+  <div>
+    <button onclick={() => drawingMode = google.maps.drawing.OverlayType.MARKER}>
+      Draw Marker
+    </button>
+    <button onclick={() => drawingMode = google.maps.drawing.OverlayType.POLYGON}>
+      Draw Polygon
+    </button>
+    <button onclick={() => drawingMode = null}>
+      Stop Drawing
+    </button>
+  </div>
+  
+  <GoogleMap
+    zoom={12}
+    center={{ lat: 35.6812362, lng: 139.7649361 }}
+    options={{ mapTypeId: 'roadmap' }}
+  >
+    <DrawingManager
+      {drawingMode}
+      drawingControl={false}
+    />
+  </GoogleMap>
+</APIProvider>
+```
+
+## Note
+
+Remember to include the `drawing` library when initializing the API Provider:
+
+```svelte
+<APIProvider apiKey={YOUR_API_KEY} libraries={['drawing']}>
+```

--- a/apps/docs/src/routes/components/drawing-manager/+page.md
+++ b/apps/docs/src/routes/components/drawing-manager/+page.md
@@ -1,158 +1,41 @@
-# DrawingManager
+---
+title: DrawingManager
+---
 
-The `DrawingManager` component provides a graphical interface for users to draw overlays on the map, including markers, polylines, polygons, rectangles, and circles.
+## Storybook
 
-## Basic Usage
+[Open the DrawingManager story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-drawingmanager--basic)
 
-```svelte
-<script>
-  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
-</script>
-
-<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
-  <GoogleMap
-    zoom={12}
-    center={{ lat: 35.6812362, lng: 139.7649361 }}
-    options={{ mapTypeId: 'roadmap' }}
-  >
-    <DrawingManager
-      drawingControl={true}
-      drawingControlOptions={{
-        position: google.maps.ControlPosition.TOP_CENTER,
-        drawingModes: [
-          google.maps.drawing.OverlayType.MARKER,
-          google.maps.drawing.OverlayType.CIRCLE,
-          google.maps.drawing.OverlayType.POLYGON,
-          google.maps.drawing.OverlayType.POLYLINE,
-          google.maps.drawing.OverlayType.RECTANGLE
-        ]
-      }}
-    />
-  </GoogleMap>
-</APIProvider>
-```
+The `DrawingManager` component provides Google Maps drawing controls for markers, polylines, polygons, rectangles, and circles.
 
 ## Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `drawingMode` | `google.maps.drawing.OverlayType \| null` | `null` | The current drawing mode |
-| `drawingControl` | `boolean` | `true` | Whether the drawing control UI is displayed |
-| `drawingControlOptions` | `google.maps.drawing.DrawingControlOptions` | `undefined` | Options for the drawing control |
-| `circleOptions` | `google.maps.CircleOptions` | `undefined` | Default options for circles |
-| `markerOptions` | `google.maps.MarkerOptions` | `undefined` | Default options for markers |
-| `polygonOptions` | `google.maps.PolygonOptions` | `undefined` | Default options for polygons |
-| `polylineOptions` | `google.maps.PolylineOptions` | `undefined` | Default options for polylines |
-| `rectangleOptions` | `google.maps.RectangleOptions` | `undefined` | Default options for rectangles |
+| drawingMode | `google.maps.drawing.OverlayType \| null` | `null` | Active drawing mode. |
+| drawingControl | `boolean` | `true` | Shows the drawing control UI. |
+| drawingControlOptions | `google.maps.drawing.DrawingControlOptions` | | Drawing control options. |
+| markerOptions | `google.maps.MarkerOptions` | | Options for drawn markers. |
+| circleOptions | `google.maps.CircleOptions` | | Options for drawn circles. |
+| polygonOptions | `google.maps.PolygonOptions` | | Options for drawn polygons. |
+| polylineOptions | `google.maps.PolylineOptions` | | Options for drawn polylines. |
+| rectangleOptions | `google.maps.RectangleOptions` | | Options for drawn rectangles. |
+| onLoad | `(manager: google.maps.drawing.DrawingManager) => void` | | Called after creation. |
+| onUnmount | `(manager: google.maps.drawing.DrawingManager) => void` | | Called before teardown. |
 
 ## Events
 
-| Event | Type | Description |
-|-------|------|-------------|
-| `onCircleComplete` | `(circle: google.maps.Circle) => void` | Called when a circle is completed |
-| `onMarkerComplete` | `(marker: google.maps.Marker) => void` | Called when a marker is completed |
-| `onOverlayComplete` | `(event: google.maps.drawing.OverlayCompleteEvent) => void` | Called when any overlay is completed |
-| `onPolygonComplete` | `(polygon: google.maps.Polygon) => void` | Called when a polygon is completed |
-| `onPolylineComplete` | `(polyline: google.maps.Polyline) => void` | Called when a polyline is completed |
-| `onRectangleComplete` | `(rectangle: google.maps.Rectangle) => void` | Called when a rectangle is completed |
-| `onDrawingModeChange` | `() => void` | Called when the drawing mode changes |
-| `onLoad` | `(drawingManager: google.maps.drawing.DrawingManager) => void` | Called when the DrawingManager is loaded |
-| `onUnmount` | `(drawingManager: google.maps.drawing.DrawingManager) => void` | Called when the DrawingManager is unmounted |
+`onCircleComplete`, `onMarkerComplete`, `onOverlayComplete`, `onPolygonComplete`, `onPolylineComplete`, `onRectangleComplete`, and `onDrawingModeChange` map to the Google Maps drawing events.
 
-## Example with Custom Styling
+## Usage
 
 ```svelte
-<script>
-  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
-
-  let drawnShapes = [];
-
-  function handleOverlayComplete(event) {
-    drawnShapes.push(event.overlay);
-    // You can store the overlay for later manipulation
-    console.log('New shape drawn:', event.type);
-  }
-</script>
-
-<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
-  <GoogleMap
-    zoom={12}
-    center={{ lat: 35.6812362, lng: 139.7649361 }}
-    options={{ mapTypeId: 'roadmap' }}
-  >
+<APIProvider apiKey="YOUR_API_KEY" libraries={['drawing']}>
+  <GoogleMap options={{ center, zoom: 12 }}>
     <DrawingManager
-      drawingControl={true}
-      circleOptions={{
-        fillColor: '#ff0000',
-        fillOpacity: 0.35,
-        strokeWeight: 2,
-        clickable: true,
-        editable: true,
-        zIndex: 1
-      }}
-      polygonOptions={{
-        fillColor: '#00ff00',
-        fillOpacity: 0.35,
-        strokeWeight: 2,
-        clickable: true,
-        editable: true,
-        zIndex: 1
-      }}
-      rectangleOptions={{
-        fillColor: '#0000ff',
-        fillOpacity: 0.35,
-        strokeWeight: 2,
-        clickable: true,
-        editable: true,
-        zIndex: 1
-      }}
-      onOverlayComplete={handleOverlayComplete}
+      drawingControl
+      onOverlayComplete={(event) => console.log(event.type, event.overlay)}
     />
   </GoogleMap>
 </APIProvider>
-```
-
-## Drawing Mode Control
-
-You can programmatically control the drawing mode:
-
-```svelte
-<script>
-  import { APIProvider, GoogleMap, DrawingManager } from 'svelte-google-maps-api';
-
-  let drawingMode = null;
-</script>
-
-<APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY} libraries={['drawing']}>
-  <div>
-    <button onclick={() => drawingMode = google.maps.drawing.OverlayType.MARKER}>
-      Draw Marker
-    </button>
-    <button onclick={() => drawingMode = google.maps.drawing.OverlayType.POLYGON}>
-      Draw Polygon
-    </button>
-    <button onclick={() => drawingMode = null}>
-      Stop Drawing
-    </button>
-  </div>
-  
-  <GoogleMap
-    zoom={12}
-    center={{ lat: 35.6812362, lng: 139.7649361 }}
-    options={{ mapTypeId: 'roadmap' }}
-  >
-    <DrawingManager
-      {drawingMode}
-      drawingControl={false}
-    />
-  </GoogleMap>
-</APIProvider>
-```
-
-## Note
-
-Remember to include the `drawing` library when initializing the API Provider:
-
-```svelte
-<APIProvider apiKey={YOUR_API_KEY} libraries={['drawing']}>
 ```

--- a/apps/docs/src/routes/components/google-map/+page.md
+++ b/apps/docs/src/routes/components/google-map/+page.md
@@ -2,6 +2,10 @@
 title: GoogleMap
 ---
 
+## Storybook
+
+[Open the GoogleMap story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-googlemap--basic)
+
 The GoogleMap component renders a Google Map instance.
 
 ## Props

--- a/apps/docs/src/routes/components/google-marker-clusterer/+page.md
+++ b/apps/docs/src/routes/components/google-marker-clusterer/+page.md
@@ -1,0 +1,29 @@
+---
+title: GoogleMarkerClusterer
+---
+
+The `GoogleMarkerClusterer` component wraps `@googlemaps/markerclusterer` and clusters child `Marker` or `AdvancedMarker` components.
+
+## Storybook
+
+[Open the GoogleMarkerClusterer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-googlemarkerclusterer--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `Omit<MarkerClustererOptions, 'map' \| 'markers'>` | Marker clusterer options. |
+| markers | `Marker[]` | Optional marker instances to cluster. Child markers register automatically. |
+| onClusterClick | `MarkerClustererOptions['onClusterClick']` | Cluster click handler. |
+| onLoad | `(clusterer) => void` | Called after clusterer creation. |
+| onUnmount | `(clusterer) => void` | Called before clusterer removal. |
+
+## Usage
+
+```svelte
+<GoogleMarkerClusterer>
+  {#each locations as position}
+    <Marker {position} />
+  {/each}
+</GoogleMarkerClusterer>
+```

--- a/apps/docs/src/routes/components/ground-overlay/+page.md
+++ b/apps/docs/src/routes/components/ground-overlay/+page.md
@@ -1,6 +1,10 @@
 ---
 title: GroundOverlay
 ---
+
+## Storybook
+
+[Open the GroundOverlay story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-groundoverlay--basic)
 A component to display an image on the map, fitted to the specified bounds.
 
 Must be used within a `<GoogleMap>` component.

--- a/apps/docs/src/routes/components/heatmap-layer/+page.md
+++ b/apps/docs/src/routes/components/heatmap-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: HeatmapLayer
 ---
+
+## Storybook
+
+[Open the HeatmapLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-heatmaplayer--basic)
 A component to display a heatmap layer on the map.
 Requires the `visualization` library. Please specify `libraries={['visualization']}` in the `<APIProvider>` props.
 

--- a/apps/docs/src/routes/components/info-box/+page.md
+++ b/apps/docs/src/routes/components/info-box/+page.md
@@ -1,0 +1,33 @@
+---
+title: InfoBox
+---
+
+The `InfoBox` component renders custom styled content in a Google Maps overlay pane.
+
+## Storybook
+
+[Open the InfoBox story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-infobox--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| anchor | `google.maps.MVCObject` | Optional anchor object. |
+| position | `google.maps.LatLng \| google.maps.LatLngLiteral` | Position used when no anchor is provided. |
+| options | `InfoBoxOptions` | InfoBox options such as `boxClass`, `boxStyle`, `pixelOffset`, and `closeBoxURL`. |
+| zIndex | `number` | Overlay z-index. |
+| isOpen | `boolean` | Opens or closes the InfoBox. |
+| onLoad | `(infoBox) => void` | Called after creation. |
+| onUnmount | `(infoBox) => void` | Called before removal. |
+
+## Events
+
+`onCloseClick`, `onDomReady`, `onContentChanged`, `onPositionChanged`, and `onZindexChanged` map to the corresponding InfoBox events.
+
+## Usage
+
+```svelte
+<InfoBox position={center} options={{ closeBoxURL: '', boxClass: 'info-box' }}>
+  <strong>Custom overlay content</strong>
+</InfoBox>
+```

--- a/apps/docs/src/routes/components/info-window/+page.md
+++ b/apps/docs/src/routes/components/info-window/+page.md
@@ -2,6 +2,10 @@
 title: InfoWindow
 ---
 
+## Storybook
+
+[Open the InfoWindow story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-infowindow--basic)
+
 The `InfoWindow` component creates and manages info windows on the map, which can display content when opened.
 
 ## Props

--- a/apps/docs/src/routes/components/kml-layer/+page.md
+++ b/apps/docs/src/routes/components/kml-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: KmlLayer
 ---
+
+## Storybook
+
+[Open the KmlLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-kmllayer--basic)
 A component to display data from a KML (Keyhole Markup Language) file on the map.
 
 Must be used within a `<GoogleMap>` component.

--- a/apps/docs/src/routes/components/map-control/+page.md
+++ b/apps/docs/src/routes/components/map-control/+page.md
@@ -1,6 +1,10 @@
 ---
 title: MapControl
 ---
+
+## Storybook
+
+[Open the MapControl story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-mapcontrol--basic)
 A component to add custom control elements to the map.
 Displays the HTML elements placed within its slot at the specified position.
 

--- a/apps/docs/src/routes/components/marker-clusterer/+page.md
+++ b/apps/docs/src/routes/components/marker-clusterer/+page.md
@@ -1,0 +1,30 @@
+---
+title: MarkerClusterer
+---
+
+The `MarkerClusterer` component clusters child markers. It uses the modern `@googlemaps/markerclusterer` implementation while keeping a React-compatible `onClick(cluster)` convenience prop.
+
+## Storybook
+
+[Open the MarkerClusterer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-markerclusterer--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| options | `Omit<MarkerClustererOptions, 'map' \| 'markers'>` | Marker clusterer options. |
+| markers | `Marker[]` | Optional marker instances to cluster. Child markers register automatically. |
+| onClick | `(cluster) => void` | Convenience cluster click handler. |
+| onClusterClick | `MarkerClustererOptions['onClusterClick']` | Native cluster click handler. |
+| onLoad | `(clusterer) => void` | Called after clusterer creation. |
+| onUnmount | `(clusterer) => void` | Called before clusterer removal. |
+
+## Usage
+
+```svelte
+<MarkerClusterer onClick={(cluster) => console.log(cluster.count)}>
+  {#each locations as position}
+    <Marker {position} />
+  {/each}
+</MarkerClusterer>
+```

--- a/apps/docs/src/routes/components/marker/+page.md
+++ b/apps/docs/src/routes/components/marker/+page.md
@@ -2,6 +2,10 @@
 title: Marker
 ---
 
+## Storybook
+
+[Open the Marker story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-marker--basic)
+
 The `Marker` component creates and manages markers on the map.
 
 ## Props

--- a/apps/docs/src/routes/components/overlay-view/+page.md
+++ b/apps/docs/src/routes/components/overlay-view/+page.md
@@ -1,6 +1,10 @@
 ---
 title: OverlayView
 ---
+
+## Storybook
+
+[Open the OverlayView story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-overlayview--basic)
 A component for displaying custom HTML elements (`<slot>`) as an overlay at a specified position or bounds on the map.
 Wraps `google.maps.OverlayView` to integrate Svelte components into map panes.
 
@@ -40,6 +44,10 @@ Must be used within a `<GoogleMap>` component.
 | `position`    | `google.maps.LatLng \| google.maps.LatLngLiteral \| undefined`        | `undefined`   | The single geographical coordinate where the overlay should be displayed. If provided along with `bounds`, `position` takes precedence.                                              |
 | `bounds`      | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral \| undefined` | `undefined`   | The geographical bounds where the overlay should be displayed. If provided, the slot content will be stretched to fit these bounds. Used only if `position` is not provided.      |
 | `mapPaneName` | `keyof google.maps.MapPanes`                                       | `'floatPane'` | The name of the map pane where the overlay's container element should be added. See [MapPanes documentation](https://developers.google.com/maps/documentation/javascript/reference/map#MapPanes) for available pane names. |
+
+## Pane constants
+
+`FLOAT_PANE`, `MAP_PANE`, `MARKER_LAYER`, `OVERLAY_LAYER`, and `OVERLAY_MOUSE_TARGET` are exported from `svelte-google-maps-api` for convenient pane selection.
 
 **Note:** You cannot specify both `position` and `bounds` simultaneously. Provide one or the other, or neither (in which case the overlay won't be displayed).
 

--- a/apps/docs/src/routes/components/polygon/+page.md
+++ b/apps/docs/src/routes/components/polygon/+page.md
@@ -2,6 +2,10 @@
 title: Polygon
 ---
 
+## Storybook
+
+[Open the Polygon story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-polygon--basic)
+
 The `Polygon` component draws a closed shape on the map defined by a series of coordinates.
 
 ## Props

--- a/apps/docs/src/routes/components/polyline/+page.md
+++ b/apps/docs/src/routes/components/polyline/+page.md
@@ -2,6 +2,10 @@
 title: Polyline
 ---
 
+## Storybook
+
+[Open the Polyline story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-polyline--basic)
+
 The `Polyline` component draws a line on the map connecting a series of locations.
 
 ## Props

--- a/apps/docs/src/routes/components/rectangle/+page.md
+++ b/apps/docs/src/routes/components/rectangle/+page.md
@@ -2,6 +2,10 @@
 title: Rectangle
 ---
 
+## Storybook
+
+[Open the Rectangle story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-rectangle--basic)
+
 The `Rectangle` component draws a rectangle on the map defined by southwest and northeast coordinates.
 
 ## Props

--- a/apps/docs/src/routes/components/standalone-search-box/+page.md
+++ b/apps/docs/src/routes/components/standalone-search-box/+page.md
@@ -1,0 +1,40 @@
+---
+title: StandaloneSearchBox
+---
+
+The `StandaloneSearchBox` component wraps `google.maps.places.SearchBox` for free-form place search outside a map control.
+
+## Storybook
+
+[Open the StandaloneSearchBox story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-standalonesearchbox--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| bounds | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral` | Biases results to a bounds area. |
+| options | `google.maps.places.SearchBoxOptions` | Initial SearchBox options. |
+| value | `string` | Input value when using the built-in input. |
+| placeholder | `string` | Input placeholder when using the built-in input. |
+| inputId | `string` | Built-in input id. |
+| inputClass | `string` | Built-in input class. |
+| inputStyle | `string` | Built-in input inline style. |
+| disabled | `boolean` | Disables the built-in input. |
+| onPlacesChanged | `(places) => void` | Called when selected places change. |
+| onLoad | `(searchBox) => void` | Called after creation. |
+| onUnmount | `(searchBox) => void` | Called before teardown. |
+
+## Events
+
+The component also dispatches `places_changed` with the selected places.
+
+## Usage
+
+```svelte
+<APIProvider apiKey="YOUR_API_KEY" libraries={['places']}>
+  <StandaloneSearchBox
+    placeholder="Search places"
+    onPlacesChanged={(places) => console.log(places)}
+  />
+</APIProvider>
+```

--- a/apps/docs/src/routes/components/street-view-panorama/+page.md
+++ b/apps/docs/src/routes/components/street-view-panorama/+page.md
@@ -1,6 +1,10 @@
 ---
 title: StreetViewPanorama
 ---
+
+## Storybook
+
+[Open the StreetViewPanorama story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-streetviewpanorama--basic)
 A component to display Street View panoramas.
 
 Must be used within an `<APIProvider>` component.

--- a/apps/docs/src/routes/components/street-view-service/+page.md
+++ b/apps/docs/src/routes/components/street-view-service/+page.md
@@ -1,0 +1,28 @@
+---
+title: StreetViewService
+---
+
+The `StreetViewService` component creates a `google.maps.StreetViewService` instance for custom panorama lookups.
+
+## Storybook
+
+[Open the StreetViewService story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-streetviewservice--basic)
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| onLoad | `(service: google.maps.StreetViewService) => void` | Called after service creation. |
+| onUnmount | `(service: google.maps.StreetViewService) => void` | Called before teardown. |
+
+## Usage
+
+```svelte
+<StreetViewService
+  onLoad={(service) => {
+    service.getPanorama({ location: center, radius: 50 }, (data, status) => {
+      console.log(status, data);
+    });
+  }}
+/>
+```

--- a/apps/docs/src/routes/components/traffic-layer/+page.md
+++ b/apps/docs/src/routes/components/traffic-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: TrafficLayer
 ---
+
+## Storybook
+
+[Open the TrafficLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-trafficlayer--basic)
 A component to display the traffic layer on the map.
 
 Must be used within a `<GoogleMap>` component.

--- a/apps/docs/src/routes/components/transit-layer/+page.md
+++ b/apps/docs/src/routes/components/transit-layer/+page.md
@@ -1,6 +1,10 @@
 ---
 title: TransitLayer
 ---
+
+## Storybook
+
+[Open the TransitLayer story](https://skyt-a.github.io/svelte-google-maps-api/storybook/?path=/story/components-transitlayer--basic)
 The `TransitLayer` component displays the public transportation network on the map.
 
 ## Usage

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -2,6 +2,38 @@ import { defineConfig } from 'vite';
 import { sveltepress } from '@sveltepress/vite';
 import { defaultTheme } from '@sveltepress/theme-default';
 
+const componentItems = [
+	{ title: 'APIProvider', to: '/components/api-provider/' },
+	{ title: 'GoogleMap', to: '/components/google-map/' },
+	{ title: 'Marker', to: '/components/marker/' },
+	{ title: 'AdvancedMarker', to: '/components/advanced-marker/' },
+	{ title: 'MarkerClusterer', to: '/components/marker-clusterer/' },
+	{ title: 'GoogleMarkerClusterer', to: '/components/google-marker-clusterer/' },
+	{ title: 'InfoWindow', to: '/components/info-window/' },
+	{ title: 'InfoBox', to: '/components/info-box/' },
+	{ title: 'Polyline', to: '/components/polyline/' },
+	{ title: 'Polygon', to: '/components/polygon/' },
+	{ title: 'Circle', to: '/components/circle/' },
+	{ title: 'Rectangle', to: '/components/rectangle/' },
+	{ title: 'Data', to: '/components/data/' },
+	{ title: 'DrawingManager', to: '/components/drawing-manager/' },
+	{ title: 'DirectionsRenderer', to: '/components/directions-renderer/' },
+	{ title: 'DirectionsService', to: '/components/directions-service/' },
+	{ title: 'DistanceMatrixService', to: '/components/distance-matrix-service/' },
+	{ title: 'HeatmapLayer', to: '/components/heatmap-layer/' },
+	{ title: 'KmlLayer', to: '/components/kml-layer/' },
+	{ title: 'TrafficLayer', to: '/components/traffic-layer/' },
+	{ title: 'TransitLayer', to: '/components/transit-layer/' },
+	{ title: 'BicyclingLayer', to: '/components/bicycling-layer/' },
+	{ title: 'GroundOverlay', to: '/components/ground-overlay/' },
+	{ title: 'MapControl', to: '/components/map-control/' },
+	{ title: 'Autocomplete', to: '/components/autocomplete/' },
+	{ title: 'StandaloneSearchBox', to: '/components/standalone-search-box/' },
+	{ title: 'OverlayView', to: '/components/overlay-view/' },
+	{ title: 'StreetViewPanorama', to: '/components/street-view-panorama/' },
+	{ title: 'StreetViewService', to: '/components/street-view-service/' }
+];
+
 export default defineConfig({
 	// base パスは GitHub Pages 用なのでそのままで良いか確認が必要
 	base: '/svelte-google-maps-api/',
@@ -12,30 +44,7 @@ export default defineConfig({
 					{ title: 'Guide', to: '/guide/getting-started' },
 					{
 						title: 'Components',
-						items: [
-							{ title: 'APIProvider', to: '/components/api-provider/' },
-							{ title: 'GoogleMap', to: '/components/google-map/' },
-							{ title: 'Marker', to: '/components/marker/' },
-							{ title: 'AdvancedMarker', to: '/components/advanced-marker/' },
-							{ title: 'InfoWindow', to: '/components/info-window/' },
-							{ title: 'Polyline', to: '/components/polyline/' },
-							{ title: 'Polygon', to: '/components/polygon/' },
-							{ title: 'Circle', to: '/components/circle/' },
-							{ title: 'Rectangle', to: '/components/rectangle/' },
-							{ title: 'HeatmapLayer', to: '/components/heatmap-layer/' },
-							{ title: 'KmlLayer', to: '/components/kml-layer/' },
-							{ title: 'TrafficLayer', to: '/components/traffic-layer/' },
-							{ title: 'TransitLayer', to: '/components/transit-layer/' },
-							{ title: 'BicyclingLayer', to: '/components/bicycling-layer/' },
-							{ title: 'GroundOverlay', to: '/components/ground-overlay/' },
-							{ title: 'MapControl', to: '/components/map-control/' },
-							{ title: 'Autocomplete', to: '/components/autocomplete/' },
-							{ title: 'OverlayView', to: '/components/overlay-view/' },
-							{
-								title: 'StreetViewPanorama',
-								to: '/components/street-view-panorama/'
-							}
-						]
+						items: componentItems
 					},
 					{ title: 'Examples', to: '/examples' },
 					{
@@ -54,30 +63,7 @@ export default defineConfig({
 					'/components/': [
 						{
 							title: 'Components',
-							items: [
-								{ title: 'APIProvider', to: '/components/api-provider/' },
-								{ title: 'GoogleMap', to: '/components/google-map/' },
-								{ title: 'Marker', to: '/components/marker/' },
-								{ title: 'AdvancedMarker', to: '/components/advanced-marker/' },
-								{ title: 'InfoWindow', to: '/components/info-window/' },
-								{ title: 'Polyline', to: '/components/polyline/' },
-								{ title: 'Polygon', to: '/components/polygon/' },
-								{ title: 'Circle', to: '/components/circle/' },
-								{ title: 'Rectangle', to: '/components/rectangle/' },
-								{ title: 'HeatmapLayer', to: '/components/heatmap-layer/' },
-								{ title: 'KmlLayer', to: '/components/kml-layer/' },
-								{ title: 'TrafficLayer', to: '/components/traffic-layer/' },
-								{ title: 'TransitLayer', to: '/components/transit-layer/' },
-								{ title: 'BicyclingLayer', to: '/components/bicycling-layer/' },
-								{ title: 'GroundOverlay', to: '/components/ground-overlay/' },
-								{ title: 'MapControl', to: '/components/map-control/' },
-								{ title: 'Autocomplete', to: '/components/autocomplete/' },
-								{ title: 'OverlayView', to: '/components/overlay-view/' },
-								{
-									title: 'StreetViewPanorama',
-									to: '/components/street-view-panorama/'
-								}
-							]
+							items: componentItems
 						}
 					]
 				},

--- a/apps/storybook/.gitignore
+++ b/apps/storybook/.gitignore
@@ -1,0 +1,1 @@
+storybook-static

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,0 +1,23 @@
+import type { StorybookConfig } from '@storybook/svelte-vite';
+
+const config: StorybookConfig = {
+	stories: ['../src/**/*.stories.@(ts|svelte)'],
+	addons: [],
+	framework: {
+		name: '@storybook/svelte-vite',
+		options: {}
+	},
+	viteFinal: async (config) => {
+		const { svelte } = await import('@sveltejs/vite-plugin-svelte');
+
+		return {
+			...config,
+			plugins: [svelte(), ...(config.plugins ?? [])]
+		};
+	},
+	docs: {
+		autodocs: true
+	}
+};
+
+export default config;

--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,0 +1,15 @@
+import type { Preview } from '@storybook/svelte';
+
+const preview: Preview = {
+	parameters: {
+		layout: 'fullscreen',
+		controls: {
+			matchers: {
+				color: /(background|color)$/i,
+				date: /Date$/i
+			}
+		}
+	}
+};
+
+export default preview;

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "storybook",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"scripts": {
+		"dev": "storybook dev -p 6006",
+		"build": "storybook build",
+		"storybook": "storybook dev -p 6006"
+	},
+	"dependencies": {
+		"svelte-google-maps-api": "workspace:*"
+	},
+	"devDependencies": {
+		"@sveltejs/vite-plugin-svelte": "^5.0.3",
+		"@storybook/svelte": "^8.6.14",
+		"@storybook/svelte-vite": "^8.6.14",
+		"storybook": "^8.6.14",
+		"svelte": "^5.28.2",
+		"typescript": "^5.0.0",
+		"vite": "^6.2.6"
+	}
+}

--- a/apps/storybook/src/stories/APIProvider.stories.ts
+++ b/apps/storybook/src/stories/APIProvider.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/APIProvider',
+	component: ComponentStory,
+	args: { componentName: 'APIProvider' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/AdvancedMarker.stories.ts
+++ b/apps/storybook/src/stories/AdvancedMarker.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/AdvancedMarker',
+	component: ComponentStory,
+	args: { componentName: 'AdvancedMarker' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Autocomplete.stories.ts
+++ b/apps/storybook/src/stories/Autocomplete.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Autocomplete',
+	component: ComponentStory,
+	args: { componentName: 'Autocomplete' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/BicyclingLayer.stories.ts
+++ b/apps/storybook/src/stories/BicyclingLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/BicyclingLayer',
+	component: ComponentStory,
+	args: { componentName: 'BicyclingLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Circle.stories.ts
+++ b/apps/storybook/src/stories/Circle.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Circle',
+	component: ComponentStory,
+	args: { componentName: 'Circle' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/ComponentStory.svelte
+++ b/apps/storybook/src/stories/ComponentStory.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+	import {
+		APIProvider,
+		AdvancedMarker,
+		Autocomplete,
+		BicyclingLayer,
+		Circle,
+		Data,
+		DirectionsRenderer,
+		DirectionsService,
+		DistanceMatrixService,
+		DrawingManager,
+		GoogleMap,
+		GoogleMarkerClusterer,
+		GroundOverlay,
+		HeatmapLayer,
+		InfoBox,
+		InfoWindow,
+		KmlLayer,
+		MapControl,
+		Marker,
+		MarkerClusterer,
+		OverlayView,
+		Polygon,
+		Polyline,
+		Rectangle,
+		StandaloneSearchBox,
+		StreetViewPanorama,
+		StreetViewService,
+		TrafficLayer,
+		TransitLayer
+	} from 'svelte-google-maps-api';
+	import type { Library } from 'svelte-google-maps-api';
+
+	export let componentName: string;
+
+	const apiKey = import.meta.env.STORYBOOK_GOOGLE_MAPS_API_KEY ?? '';
+	const center = { lat: 35.6812362, lng: 139.7649361 };
+	const second = { lat: 35.658584, lng: 139.7454316 };
+	const third = { lat: 35.710063, lng: 139.8107 };
+	const bounds = {
+		north: 35.73,
+		south: 35.64,
+		east: 139.84,
+		west: 139.69
+	};
+	const path = [center, second, third, center];
+	const mapOptions: google.maps.MapOptions = {
+		center,
+		zoom: 12,
+		mapId: 'DEMO_MAP_ID'
+	};
+	const heatmapData = [
+		{ location: center, weight: 3 },
+		{ location: second, weight: 2 },
+		{ location: third, weight: 4 }
+	];
+	const kmlUrl = 'https://developers.google.com/maps/documentation/javascript/examples/kml/westcampus.kml';
+	const groundOverlayUrl =
+		'https://developers.google.com/maps/documentation/javascript/examples/full/images/talkeetna.png';
+	const distanceRequest: google.maps.DistanceMatrixRequest = {
+		origins: [center],
+		destinations: [second],
+		travelMode: 'DRIVING' as google.maps.TravelMode
+	};
+	const directionsRequest: google.maps.DirectionsRequest = {
+		origin: center,
+		destination: second,
+		travelMode: 'DRIVING' as google.maps.TravelMode
+	};
+	const clusterLocations = [
+		center,
+		second,
+		third,
+		{ lat: 35.6895, lng: 139.6917 },
+		{ lat: 35.699, lng: 139.774 }
+	];
+
+	let directions: google.maps.DirectionsResult | undefined = undefined;
+	let serviceStatus = 'Waiting';
+	let dataLoaded = false;
+
+	$: libraries = getLibraries(componentName);
+
+	function getLibraries(name: string): Library[] {
+		if (name === 'Autocomplete' || name === 'StandaloneSearchBox') return ['places'];
+		if (name === 'DrawingManager') return ['drawing'];
+		if (name === 'HeatmapLayer') return ['visualization'];
+		if (name === 'AdvancedMarker') return ['marker'];
+		return [];
+	}
+
+	function handleDirectionsResult(
+		result: google.maps.DirectionsResult | null,
+		status: google.maps.DirectionsStatus
+	) {
+		serviceStatus = String(status);
+		if (result) directions = result;
+	}
+
+	function handleDistanceMatrix(
+		response: google.maps.DistanceMatrixResponse | null,
+		status: google.maps.DistanceMatrixStatus
+	) {
+		serviceStatus = response ? `${status}: ${response.rows.length} row` : String(status);
+	}
+
+	function handleDataLoad(data: google.maps.Data) {
+		data.addGeoJson({
+			type: 'FeatureCollection',
+			features: [
+				{
+					type: 'Feature',
+					geometry: {
+						type: 'Polygon',
+						coordinates: [
+							[
+								[139.72, 35.67],
+								[139.79, 35.67],
+								[139.79, 35.71],
+								[139.72, 35.71],
+								[139.72, 35.67]
+							]
+						]
+					},
+					properties: { name: 'Tokyo sample polygon' }
+				}
+			]
+		} as any);
+		data.setStyle({
+			fillColor: '#1d9a8a',
+			fillOpacity: 0.25,
+			strokeColor: '#1d9a8a',
+			strokeWeight: 2
+		});
+		dataLoaded = true;
+	}
+</script>
+
+{#if !apiKey}
+	<div class="missing-key">
+		<strong>{componentName}</strong>
+		<span>Set STORYBOOK_GOOGLE_MAPS_API_KEY to run this story with Google Maps.</span>
+	</div>
+{:else if componentName === 'APIProvider'}
+	<div class="map-frame">
+		<APIProvider {apiKey}>
+			<GoogleMap options={mapOptions} mapContainerStyle="width:100%;height:100%;">
+				<Marker position={center} options={{ title: 'APIProvider story marker' }} />
+			</GoogleMap>
+		</APIProvider>
+	</div>
+{:else if componentName === 'Autocomplete'}
+	<div class="panel-frame">
+		<APIProvider {apiKey} libraries={['places']}>
+			<Autocomplete placeholder="Search for a place" inputStyle="width:320px;padding:10px;" />
+		</APIProvider>
+	</div>
+{:else if componentName === 'StandaloneSearchBox'}
+	<div class="panel-frame">
+		<APIProvider {apiKey} libraries={['places']}>
+			<StandaloneSearchBox placeholder="Search places" inputStyle="width:320px;padding:10px;" />
+		</APIProvider>
+	</div>
+{:else if componentName === 'StreetViewPanorama'}
+	<div class="map-frame">
+		<APIProvider {apiKey}>
+			<StreetViewPanorama
+				position={center}
+				pov={{ heading: 165, pitch: 0 }}
+				zoom={1}
+				containerStyle="width:100%;height:100%;"
+			/>
+		</APIProvider>
+	</div>
+{:else if componentName === 'StreetViewService'}
+	<div class="panel-frame">
+		<APIProvider {apiKey}>
+			<StreetViewService onLoad={() => (serviceStatus = 'StreetViewService loaded')} />
+			<p>{serviceStatus}</p>
+		</APIProvider>
+	</div>
+{:else if componentName === 'DistanceMatrixService'}
+	<div class="panel-frame">
+		<APIProvider {apiKey}>
+			<DistanceMatrixService options={distanceRequest} callback={handleDistanceMatrix} />
+			<p>{serviceStatus}</p>
+		</APIProvider>
+	</div>
+{:else}
+	<div class="map-frame">
+		<APIProvider {apiKey} {libraries} mapIds={['DEMO_MAP_ID']}>
+			<GoogleMap options={mapOptions} mapContainerStyle="width:100%;height:100%;">
+				{#if componentName === 'GoogleMap'}
+					<Marker position={center} options={{ title: 'Tokyo Station' }} />
+				{:else if componentName === 'Marker'}
+					<Marker position={center} options={{ title: 'Marker', draggable: true }} />
+				{:else if componentName === 'AdvancedMarker'}
+					<AdvancedMarker position={center} title="Advanced marker">
+						<div class="advanced-marker">A</div>
+					</AdvancedMarker>
+				{:else if componentName === 'InfoWindow'}
+					<Marker position={center} />
+					<InfoWindow position={center}>
+						<strong>Tokyo Station</strong>
+					</InfoWindow>
+				{:else if componentName === 'InfoBox'}
+					<InfoBox
+						position={center}
+						options={{
+							boxClass: 'storybook-info-box',
+							pixelOffset: new google.maps.Size(-80, -40),
+							closeBoxURL: ''
+						}}
+					>
+						<div class="info-box">Custom InfoBox</div>
+					</InfoBox>
+				{:else if componentName === 'Polyline'}
+					<Polyline path={path} strokeColor="#0f766e" strokeWeight={4} />
+				{:else if componentName === 'Polygon'}
+					<Polygon paths={path} fillColor="#0f766e" fillOpacity={0.25} strokeColor="#0f766e" />
+				{:else if componentName === 'Circle'}
+					<Circle center={center} radius={1200} fillColor="#2563eb" fillOpacity={0.2} strokeColor="#2563eb" />
+				{:else if componentName === 'Rectangle'}
+					<Rectangle {bounds} fillColor="#f59e0b" fillOpacity={0.2} strokeColor="#f59e0b" />
+				{:else if componentName === 'Data'}
+					<Data onLoad={handleDataLoad} />
+					{#if dataLoaded}
+						<MapControl position={2 as google.maps.ControlPosition}>
+							<div class="control">Data loaded</div>
+						</MapControl>
+					{/if}
+				{:else if componentName === 'HeatmapLayer'}
+					<HeatmapLayer data={heatmapData} radius={32} opacity={0.7} />
+				{:else if componentName === 'KmlLayer'}
+					<KmlLayer url={kmlUrl} preserveViewport />
+				{:else if componentName === 'TrafficLayer'}
+					<TrafficLayer />
+				{:else if componentName === 'TransitLayer'}
+					<TransitLayer />
+				{:else if componentName === 'BicyclingLayer'}
+					<BicyclingLayer />
+				{:else if componentName === 'GroundOverlay'}
+					<GroundOverlay url={groundOverlayUrl} {bounds} opacity={0.55} />
+				{:else if componentName === 'OverlayView'}
+					<OverlayView position={center}>
+						<div class="overlay-view">OverlayView</div>
+					</OverlayView>
+				{:else if componentName === 'MapControl'}
+					<MapControl position={2 as google.maps.ControlPosition}>
+						<button class="control">Map control</button>
+					</MapControl>
+				{:else if componentName === 'DrawingManager'}
+					<DrawingManager drawingControl />
+				{:else if componentName === 'DirectionsRenderer'}
+					<DirectionsService options={directionsRequest} callback={handleDirectionsResult} />
+					{#if directions}
+						<DirectionsRenderer {directions} />
+					{/if}
+				{:else if componentName === 'DirectionsService'}
+					<DirectionsService options={directionsRequest} callback={handleDirectionsResult} />
+					<MapControl position={2 as google.maps.ControlPosition}>
+						<div class="control">Directions: {serviceStatus}</div>
+					</MapControl>
+				{:else if componentName === 'MarkerClusterer'}
+					<MarkerClusterer>
+						{#each clusterLocations as position}
+							<Marker {position} />
+						{/each}
+					</MarkerClusterer>
+				{:else if componentName === 'GoogleMarkerClusterer'}
+					<GoogleMarkerClusterer>
+						{#each clusterLocations as position}
+							<Marker {position} />
+						{/each}
+					</GoogleMarkerClusterer>
+				{/if}
+			</GoogleMap>
+		</APIProvider>
+	</div>
+{/if}
+
+<style>
+	.map-frame {
+		width: 100vw;
+		height: 100vh;
+	}
+
+	.panel-frame {
+		padding: 24px;
+		font-family:
+			Inter,
+			system-ui,
+			sans-serif;
+	}
+
+	.missing-key {
+		min-height: 100vh;
+		display: grid;
+		place-content: center;
+		gap: 8px;
+		font-family:
+			Inter,
+			system-ui,
+			sans-serif;
+		color: #1f2937;
+		background: #f8fafc;
+	}
+
+	.missing-key span {
+		color: #64748b;
+	}
+
+	.control,
+	.overlay-view,
+	.info-box {
+		background: white;
+		border: 1px solid #d1d5db;
+		border-radius: 6px;
+		box-shadow: 0 8px 24px rgba(15, 23, 42, 0.16);
+		color: #111827;
+		font: 14px/1.4 system-ui, sans-serif;
+		padding: 8px 12px;
+	}
+
+	.advanced-marker {
+		align-items: center;
+		background: #0f766e;
+		border: 2px solid white;
+		border-radius: 999px;
+		box-shadow: 0 6px 18px rgba(15, 23, 42, 0.22);
+		color: white;
+		display: flex;
+		font: 700 14px/1 system-ui, sans-serif;
+		height: 32px;
+		justify-content: center;
+		width: 32px;
+	}
+</style>

--- a/apps/storybook/src/stories/Data.stories.ts
+++ b/apps/storybook/src/stories/Data.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Data',
+	component: ComponentStory,
+	args: { componentName: 'Data' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DirectionsRenderer.stories.ts
+++ b/apps/storybook/src/stories/DirectionsRenderer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DirectionsRenderer',
+	component: ComponentStory,
+	args: { componentName: 'DirectionsRenderer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DirectionsService.stories.ts
+++ b/apps/storybook/src/stories/DirectionsService.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DirectionsService',
+	component: ComponentStory,
+	args: { componentName: 'DirectionsService' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DistanceMatrixService.stories.ts
+++ b/apps/storybook/src/stories/DistanceMatrixService.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DistanceMatrixService',
+	component: ComponentStory,
+	args: { componentName: 'DistanceMatrixService' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/DrawingManager.stories.ts
+++ b/apps/storybook/src/stories/DrawingManager.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/DrawingManager',
+	component: ComponentStory,
+	args: { componentName: 'DrawingManager' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/GoogleMap.stories.ts
+++ b/apps/storybook/src/stories/GoogleMap.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/GoogleMap',
+	component: ComponentStory,
+	args: { componentName: 'GoogleMap' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/GoogleMarkerClusterer.stories.ts
+++ b/apps/storybook/src/stories/GoogleMarkerClusterer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/GoogleMarkerClusterer',
+	component: ComponentStory,
+	args: { componentName: 'GoogleMarkerClusterer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/GroundOverlay.stories.ts
+++ b/apps/storybook/src/stories/GroundOverlay.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/GroundOverlay',
+	component: ComponentStory,
+	args: { componentName: 'GroundOverlay' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/HeatmapLayer.stories.ts
+++ b/apps/storybook/src/stories/HeatmapLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/HeatmapLayer',
+	component: ComponentStory,
+	args: { componentName: 'HeatmapLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/InfoBox.stories.ts
+++ b/apps/storybook/src/stories/InfoBox.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/InfoBox',
+	component: ComponentStory,
+	args: { componentName: 'InfoBox' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/InfoWindow.stories.ts
+++ b/apps/storybook/src/stories/InfoWindow.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/InfoWindow',
+	component: ComponentStory,
+	args: { componentName: 'InfoWindow' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/KmlLayer.stories.ts
+++ b/apps/storybook/src/stories/KmlLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/KmlLayer',
+	component: ComponentStory,
+	args: { componentName: 'KmlLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/MapControl.stories.ts
+++ b/apps/storybook/src/stories/MapControl.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/MapControl',
+	component: ComponentStory,
+	args: { componentName: 'MapControl' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Marker.stories.ts
+++ b/apps/storybook/src/stories/Marker.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Marker',
+	component: ComponentStory,
+	args: { componentName: 'Marker' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/MarkerClusterer.stories.ts
+++ b/apps/storybook/src/stories/MarkerClusterer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/MarkerClusterer',
+	component: ComponentStory,
+	args: { componentName: 'MarkerClusterer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/OverlayView.stories.ts
+++ b/apps/storybook/src/stories/OverlayView.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/OverlayView',
+	component: ComponentStory,
+	args: { componentName: 'OverlayView' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Polygon.stories.ts
+++ b/apps/storybook/src/stories/Polygon.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Polygon',
+	component: ComponentStory,
+	args: { componentName: 'Polygon' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Polyline.stories.ts
+++ b/apps/storybook/src/stories/Polyline.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Polyline',
+	component: ComponentStory,
+	args: { componentName: 'Polyline' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/Rectangle.stories.ts
+++ b/apps/storybook/src/stories/Rectangle.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/Rectangle',
+	component: ComponentStory,
+	args: { componentName: 'Rectangle' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/StandaloneSearchBox.stories.ts
+++ b/apps/storybook/src/stories/StandaloneSearchBox.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/StandaloneSearchBox',
+	component: ComponentStory,
+	args: { componentName: 'StandaloneSearchBox' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/StreetViewPanorama.stories.ts
+++ b/apps/storybook/src/stories/StreetViewPanorama.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/StreetViewPanorama',
+	component: ComponentStory,
+	args: { componentName: 'StreetViewPanorama' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/StreetViewService.stories.ts
+++ b/apps/storybook/src/stories/StreetViewService.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/StreetViewService',
+	component: ComponentStory,
+	args: { componentName: 'StreetViewService' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/TrafficLayer.stories.ts
+++ b/apps/storybook/src/stories/TrafficLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/TrafficLayer',
+	component: ComponentStory,
+	args: { componentName: 'TrafficLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/src/stories/TransitLayer.stories.ts
+++ b/apps/storybook/src/stories/TransitLayer.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import ComponentStory from './ComponentStory.svelte';
+
+const meta = {
+	title: 'Components/TransitLayer',
+	component: ComponentStory,
+	args: { componentName: 'TransitLayer' }
+} satisfies Meta<typeof ComponentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["@types/google.maps", "node"]
+	},
+	"include": [".storybook/**/*", "src/**/*"]
+}

--- a/packages/svelte-google-maps-api/.eslintignore
+++ b/packages/svelte-google-maps-api/.eslintignore
@@ -1,0 +1,3 @@
+dist
+.svelte-kit
+node_modules

--- a/packages/svelte-google-maps-api/.prettierignore
+++ b/packages/svelte-google-maps-api/.prettierignore
@@ -1,0 +1,3 @@
+dist
+.svelte-kit
+node_modules

--- a/packages/svelte-google-maps-api/package.json
+++ b/packages/svelte-google-maps-api/package.json
@@ -58,6 +58,10 @@
 			"types": "./dist/DirectionsRenderer.svelte.d.ts",
 			"svelte": "./dist/DirectionsRenderer.svelte"
 		},
+		"./DrawingManager.svelte": {
+			"types": "./dist/DrawingManager.svelte.d.ts",
+			"svelte": "./dist/DrawingManager.svelte"
+		},
 		"./MapControl.svelte": {
 			"types": "./dist/controls/MapControl.svelte.d.ts",
 			"svelte": "./dist/controls/MapControl.svelte"
@@ -97,6 +101,38 @@
 		"./Marker.svelte": {
 			"types": "./dist/Marker.svelte.d.ts",
 			"svelte": "./dist/Marker.svelte"
+		},
+		"./MarkerClusterer.svelte": {
+			"types": "./dist/MarkerClusterer.svelte.d.ts",
+			"svelte": "./dist/MarkerClusterer.svelte"
+		},
+		"./GoogleMarkerClusterer.svelte": {
+			"types": "./dist/GoogleMarkerClusterer.svelte.d.ts",
+			"svelte": "./dist/GoogleMarkerClusterer.svelte"
+		},
+		"./InfoBox.svelte": {
+			"types": "./dist/InfoBox.svelte.d.ts",
+			"svelte": "./dist/InfoBox.svelte"
+		},
+		"./Data.svelte": {
+			"types": "./dist/Data.svelte.d.ts",
+			"svelte": "./dist/Data.svelte"
+		},
+		"./DirectionsService.svelte": {
+			"types": "./dist/DirectionsService.svelte.d.ts",
+			"svelte": "./dist/DirectionsService.svelte"
+		},
+		"./DistanceMatrixService.svelte": {
+			"types": "./dist/DistanceMatrixService.svelte.d.ts",
+			"svelte": "./dist/DistanceMatrixService.svelte"
+		},
+		"./StandaloneSearchBox.svelte": {
+			"types": "./dist/places/StandaloneSearchBox.svelte.d.ts",
+			"svelte": "./dist/places/StandaloneSearchBox.svelte"
+		},
+		"./StreetViewService.svelte": {
+			"types": "./dist/street-view/StreetViewService.svelte.d.ts",
+			"svelte": "./dist/street-view/StreetViewService.svelte"
 		}
 	},
 	"files": [
@@ -117,6 +153,7 @@
 		"typescript": "^5.0.0"
 	},
 	"dependencies": {
+		"@googlemaps/markerclusterer": "^2.6.2",
 		"esm-env": "^1.0.0"
 	},
 	"keywords": [

--- a/packages/svelte-google-maps-api/src/lib/APIProvider.svelte
+++ b/packages/svelte-google-maps-api/src/lib/APIProvider.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-	import type { Library } from '$lib/types/googleMap.js';
+	import type { Library } from './types/googleMap.js';
 
 	type LoadStatus = 'loading' | 'loaded' | 'error';
 
@@ -14,79 +14,117 @@
 	import { BROWSER as browser } from 'esm-env';
 	import { setContext, onDestroy } from 'svelte';
 	import { writable, type Writable } from 'svelte/store';
+	import { preventGoogleFonts } from './utils/preventGoogleFonts.js';
 
 	export let apiKey = '';
+	export let googleMapsApiKey: string | undefined = undefined;
+	export let googleMapsClientId: string | undefined = undefined;
 	export let libraries: Library[] = [];
 	export let language: string | undefined = undefined;
 	export let region: string | undefined = undefined;
-	export let version: string | undefined = undefined;
+	export let version: string | undefined = 'weekly';
+	export let channel: string | undefined = undefined;
+	export let mapIds: string[] | undefined = undefined;
+	export let authReferrerPolicy: 'origin' | undefined = undefined;
+	export let apiUrl: string = 'https://maps.googleapis.com';
 	export let solutionChannel: string | undefined = undefined;
+	export let id: string = 'svelte-google-maps-api-script';
+	export let nonce: string | undefined = undefined;
+	export let preventGoogleFontsLoading: boolean = false;
+	export let onLoad: (() => void) | undefined = undefined;
+	export let onError: ((error: Error) => void) | undefined = undefined;
+	export let onUnmount: (() => void) | undefined = undefined;
 
 	let googleMapsApi: typeof google.maps | null = null;
 	let error: Error | null = null;
 
 	const statusStore = writable<LoadStatus>('loading');
 
-	const SCRIPT_ID = 'svelte-google-maps-api-script';
 	const CALLBACK_NAME = '__svelteGoogleMapApiCallback__';
 
 	let scriptElement: HTMLScriptElement | null = null;
+	type CallbackWindow = Window & Record<string, (() => void) | undefined>;
 
-	$: if (browser && !document.getElementById(SCRIPT_ID)) {
-		if (!apiKey) {
-			console.error('svelte-google-maps-api: apiKey is required for APIProvider');
+	$: if (browser && !document.getElementById(id)) {
+		const resolvedApiKey = googleMapsApiKey ?? apiKey;
+
+		if (resolvedApiKey && googleMapsClientId) {
+			const apiKeyError = new Error('Specify either apiKey/googleMapsApiKey or googleMapsClientId, not both');
+			console.error(`svelte-google-maps-api: ${apiKeyError.message}`);
 			statusStore.set('error');
-			error = new Error('apiKey is required');
+			error = apiKeyError;
+			onError?.(apiKeyError);
+		} else if (!resolvedApiKey && !googleMapsClientId) {
+			console.error('svelte-google-maps-api: apiKey or googleMapsClientId is required for APIProvider');
+			statusStore.set('error');
+			error = new Error('apiKey or googleMapsClientId is required');
+			onError?.(error);
 		} else {
 			statusStore.set('loading');
 			error = null;
 
-			window[CALLBACK_NAME] = () => {
+			const callbackWindow = window as unknown as CallbackWindow;
+
+			callbackWindow[CALLBACK_NAME] = () => {
 				googleMapsApi = window.google.maps;
 				statusStore.set('loaded');
+				onLoad?.();
 
 				try {
-					delete window[CALLBACK_NAME];
+					delete callbackWindow[CALLBACK_NAME];
 				} catch (e) {
-					window[CALLBACK_NAME] = undefined;
+					callbackWindow[CALLBACK_NAME] = undefined;
 				}
 			};
 
 			const script = document.createElement('script');
-			script.id = SCRIPT_ID;
+			script.id = id;
 			script.type = 'text/javascript';
+			if (nonce) script.nonce = nonce;
 			const params = new URLSearchParams();
-			params.set('key', apiKey);
+			if (resolvedApiKey) {
+				params.set('key', resolvedApiKey);
+			} else if (googleMapsClientId) {
+				params.set('client', googleMapsClientId);
+			}
 			params.set('callback', CALLBACK_NAME);
+			params.set('loading', 'async');
 			if (libraries.length > 0) {
-				params.set('libraries', libraries.sort().join(','));
+				params.set('libraries', [...libraries].sort().join(','));
 			}
 			if (language) params.set('language', language);
 			if (region) params.set('region', region);
 			if (version) params.set('v', version);
+			if (channel) params.set('channel', channel);
+			if (mapIds?.length) params.set('map_ids', mapIds.join(','));
+			if (authReferrerPolicy) params.set('auth_referrer_policy', authReferrerPolicy);
 			if (solutionChannel) params.set('solution_channel', solutionChannel);
 
-			script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
+			script.src = `${apiUrl.replace(/\/$/, '')}/maps/api/js?${params.toString()}`;
 			script.async = true;
 			script.defer = true;
 			script.onerror = (event: Event | string) => {
 				console.error('svelte-google-maps-api: Failed to load Google Maps API script.', event);
 				statusStore.set('error');
 				error = new Error(`Failed to load Google Maps script: ${event.toString()}`);
+				onError?.(error);
 
 				try {
-					delete window[CALLBACK_NAME];
+					delete callbackWindow[CALLBACK_NAME];
 				} catch (e) {
-					window[CALLBACK_NAME] = undefined;
+					callbackWindow[CALLBACK_NAME] = undefined;
 				}
 				if (scriptElement) document.head.removeChild(scriptElement);
 				scriptElement = null;
 			};
 
 			scriptElement = script;
+			if (preventGoogleFontsLoading) {
+				preventGoogleFonts();
+			}
 			document.head.appendChild(scriptElement);
 		}
-	} else if (browser && document.getElementById(SCRIPT_ID) && window.google && window.google.maps) {
+	} else if (browser && document.getElementById(id) && window.google && window.google.maps) {
 		statusStore.set('loaded');
 		googleMapsApi = window.google.maps;
 	}
@@ -99,13 +137,15 @@
 
 	onDestroy(() => {
 		if (browser) {
-			if (typeof window[CALLBACK_NAME] !== 'undefined') {
+			const callbackWindow = window as unknown as CallbackWindow;
+			if (typeof callbackWindow[CALLBACK_NAME] !== 'undefined') {
 				try {
-					delete window[CALLBACK_NAME];
+					delete callbackWindow[CALLBACK_NAME];
 				} catch (e) {
-					window[CALLBACK_NAME] = undefined;
+					callbackWindow[CALLBACK_NAME] = undefined;
 				}
 			}
+			onUnmount?.();
 		}
 	});
 </script>

--- a/packages/svelte-google-maps-api/src/lib/AdvancedMarker.svelte
+++ b/packages/svelte-google-maps-api/src/lib/AdvancedMarker.svelte
@@ -2,12 +2,15 @@
 	import { getContext, onDestroy, onMount, tick } from 'svelte';
 	import { BROWSER as browser } from 'esm-env';
 	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { ClusterableMarker, MarkerClustererContext } from './types/markerClusterer.js';
 
 	export let position: google.maps.LatLng | google.maps.LatLngLiteral | undefined = undefined;
 	export let title: string | undefined = undefined;
 	export let zIndex: number | undefined = undefined;
 	export let element: HTMLElement | undefined = undefined;
 	export let gmpDraggable: boolean | undefined = undefined;
+	export let options: Partial<google.maps.marker.AdvancedMarkerElementOptions> | undefined =
+		undefined;
 
 	export let onClick: ((e: google.maps.MapMouseEvent) => void) | undefined = undefined;
 	export let onDrag: ((e: google.maps.MapMouseEvent) => void) | undefined = undefined;
@@ -19,6 +22,7 @@
 		undefined;
 
 	let markerInstance: google.maps.marker.AdvancedMarkerElement | null = null;
+	let isClustered = false;
 	let contentWrapper: HTMLDivElement | null = null;
 	let clickListener: google.maps.MapsEventListener | null = null;
 	let dragListener: google.maps.MapsEventListener | null = null;
@@ -27,6 +31,7 @@
 
 	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
 	const map = getContext<google.maps.Map>('map');
+	const markerClusterer = getContext<MarkerClustererContext | undefined>('markerClusterer');
 
 	onDestroy(() => {
 		if (markerInstance) {
@@ -35,8 +40,13 @@
 			if (googleMapsApi) {
 				googleMapsApi.event.clearInstanceListeners(markerInstance);
 			}
-			markerInstance.map = null;
+			if (isClustered && markerClusterer) {
+				markerClusterer.removeMarker(markerInstance as ClusterableMarker);
+			} else {
+				markerInstance.map = null;
+			}
 			markerInstance = null;
+			isClustered = false;
 		}
 	});
 
@@ -60,16 +70,21 @@
 		}
 
 		const markerOptions: google.maps.marker.AdvancedMarkerElementOptions = {
-			map,
-			position,
-			title,
-			zIndex,
-			content: markerContent,
-			gmpDraggable
+			...(options ?? {}),
+			...(markerClusterer ? {} : { map }),
+			position: position ?? options?.position,
+			title: title ?? options?.title,
+			zIndex: zIndex ?? options?.zIndex,
+			content: markerContent ?? options?.content,
+			gmpDraggable: gmpDraggable ?? options?.gmpDraggable
 		};
 
 		try {
 			markerInstance = new googleMapsApi.marker.AdvancedMarkerElement(markerOptions);
+			if (markerClusterer) {
+				markerClusterer.addMarker(markerInstance as ClusterableMarker);
+				isClustered = true;
+			}
 			onLoad?.(markerInstance);
 		} catch (error) {
 			console.error('[AdvancedMarker] Error creating instance:', error);

--- a/packages/svelte-google-maps-api/src/lib/Circle.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Circle.svelte
@@ -101,24 +101,23 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onCenterChanged: 'center_changed',
-			onRadiusChanged: 'radius_changed',
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['center_changed', onCenterChanged],
+			['radius_changed', onRadiusChanged],
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(circleInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/Data.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Data.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let options: google.maps.Data.DataOptions | undefined = undefined;
+
+	export let onClick: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onDblClick: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseDown: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseMove: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseOut: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseOver: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onMouseUp: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onRightClick: ((e: google.maps.Data.MouseEvent) => void) | undefined = undefined;
+	export let onAddFeature: ((e: google.maps.Data.AddFeatureEvent) => void) | undefined = undefined;
+	export let onRemoveFeature: ((e: google.maps.Data.RemoveFeatureEvent) => void) | undefined =
+		undefined;
+	export let onRemoveProperty: ((e: google.maps.Data.RemovePropertyEvent) => void) | undefined =
+		undefined;
+	export let onSetGeometry: ((e: google.maps.Data.SetGeometryEvent) => void) | undefined =
+		undefined;
+	export let onSetProperty: ((e: google.maps.Data.SetPropertyEvent) => void) | undefined =
+		undefined;
+	export let onLoad: ((data: google.maps.Data) => void) | undefined = undefined;
+	export let onUnmount: ((data: google.maps.Data) => void) | undefined = undefined;
+
+	let data: google.maps.Data | null = null;
+	let listeners: google.maps.MapsEventListener[] = [];
+	let listenerDeps: unknown[] = [];
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	function clearListeners() {
+		if (!googleMapsApi) return;
+		listeners.forEach((listener) => googleMapsApi.event.removeListener(listener));
+		listeners = [];
+	}
+
+	function addListener<T>(
+		instance: google.maps.Data,
+		eventName: string,
+		handler: ((event: T) => void) | undefined
+	) {
+		if (handler && googleMapsApi) {
+			listeners.push(googleMapsApi.event.addListener(instance, eventName, handler));
+		}
+	}
+
+	function setupListeners() {
+		if (!data || !googleMapsApi) return;
+
+		clearListeners();
+		addListener<google.maps.Data.MouseEvent>(data, 'click', onClick);
+		addListener<google.maps.Data.MouseEvent>(data, 'dblclick', onDblClick);
+		addListener<google.maps.Data.MouseEvent>(data, 'mousedown', onMouseDown);
+		addListener<google.maps.Data.MouseEvent>(data, 'mousemove', onMouseMove);
+		addListener<google.maps.Data.MouseEvent>(data, 'mouseout', onMouseOut);
+		addListener<google.maps.Data.MouseEvent>(data, 'mouseover', onMouseOver);
+		addListener<google.maps.Data.MouseEvent>(data, 'mouseup', onMouseUp);
+		addListener<google.maps.Data.MouseEvent>(data, 'rightclick', onRightClick);
+		addListener<google.maps.Data.AddFeatureEvent>(data, 'addfeature', onAddFeature);
+		addListener<google.maps.Data.RemoveFeatureEvent>(data, 'removefeature', onRemoveFeature);
+		addListener<google.maps.Data.RemovePropertyEvent>(data, 'removeproperty', onRemoveProperty);
+		addListener<google.maps.Data.SetGeometryEvent>(data, 'setgeometry', onSetGeometry);
+		addListener<google.maps.Data.SetPropertyEvent>(data, 'setproperty', onSetProperty);
+	}
+
+	function applyOptions(nextOptions: google.maps.Data.DataOptions | undefined) {
+		if (!data || !nextOptions) return;
+
+		if (nextOptions.controlPosition !== undefined) {
+			data.setControlPosition(nextOptions.controlPosition);
+		}
+		if (nextOptions.controls !== undefined) {
+			data.setControls(nextOptions.controls);
+		}
+		if (nextOptions.drawingMode !== undefined) {
+			data.setDrawingMode(nextOptions.drawingMode);
+		}
+		if (nextOptions.style !== undefined) {
+			data.setStyle(nextOptions.style);
+		}
+	}
+
+	$: if ($status === 'loaded' && googleMapsApi && map && !data && browser) {
+		data = new googleMapsApi.Data({
+			...(options ?? {}),
+			map
+		});
+		setupListeners();
+		onLoad?.(data);
+	}
+
+	$: if (data && options) {
+		applyOptions(options);
+	}
+
+	$: listenerDeps = [
+		onClick,
+		onDblClick,
+		onMouseDown,
+		onMouseMove,
+		onMouseOut,
+		onMouseOver,
+		onMouseUp,
+		onRightClick,
+		onAddFeature,
+		onRemoveFeature,
+		onRemoveProperty,
+		onSetGeometry,
+		onSetProperty
+	];
+
+	$: if (data && googleMapsApi && browser && listenerDeps) {
+		setupListeners();
+	}
+
+	onDestroy(() => {
+		if (data) {
+			clearListeners();
+			onUnmount?.(data);
+			data.setMap(null);
+			data = null;
+		}
+	});
+</script>
+
+{#if data}
+	<slot />
+{/if}

--- a/packages/svelte-google-maps-api/src/lib/DirectionsService.svelte
+++ b/packages/svelte-google-maps-api/src/lib/DirectionsService.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let options: google.maps.DirectionsRequest;
+	export let callback: (
+		result: google.maps.DirectionsResult | null,
+		status: google.maps.DirectionsStatus
+	) => void;
+	export let onLoad: ((directionsService: google.maps.DirectionsService) => void) | undefined =
+		undefined;
+	export let onUnmount: ((directionsService: google.maps.DirectionsService) => void) | undefined =
+		undefined;
+
+	let directionsService: google.maps.DirectionsService | null = null;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	$: if ($status === 'loaded' && googleMapsApi && !directionsService && browser) {
+		directionsService = new googleMapsApi.DirectionsService();
+		onLoad?.(directionsService);
+	}
+
+	$: if (directionsService && options && callback) {
+		directionsService.route(options, callback);
+	}
+
+	onDestroy(() => {
+		if (directionsService) {
+			onUnmount?.(directionsService);
+			directionsService = null;
+		}
+	});
+</script>

--- a/packages/svelte-google-maps-api/src/lib/DistanceMatrixService.svelte
+++ b/packages/svelte-google-maps-api/src/lib/DistanceMatrixService.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let options: google.maps.DistanceMatrixRequest;
+	export let callback: (
+		response: google.maps.DistanceMatrixResponse | null,
+		status: google.maps.DistanceMatrixStatus
+	) => void;
+	export let onLoad:
+		| ((distanceMatrixService: google.maps.DistanceMatrixService) => void)
+		| undefined = undefined;
+	export let onUnmount:
+		| ((distanceMatrixService: google.maps.DistanceMatrixService) => void)
+		| undefined = undefined;
+
+	let distanceMatrixService: google.maps.DistanceMatrixService | null = null;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	$: if ($status === 'loaded' && googleMapsApi && !distanceMatrixService && browser) {
+		distanceMatrixService = new googleMapsApi.DistanceMatrixService();
+		onLoad?.(distanceMatrixService);
+	}
+
+	$: if (distanceMatrixService && options && callback) {
+		distanceMatrixService.getDistanceMatrix(options, callback);
+	}
+
+	onDestroy(() => {
+		if (distanceMatrixService) {
+			onUnmount?.(distanceMatrixService);
+			distanceMatrixService = null;
+		}
+	});
+</script>

--- a/packages/svelte-google-maps-api/src/lib/DrawingManager.svelte
+++ b/packages/svelte-google-maps-api/src/lib/DrawingManager.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let drawingMode: google.maps.drawing.OverlayType | null = null;
+	export let drawingControlOptions: google.maps.drawing.DrawingControlOptions | undefined = undefined;
+	export let circleOptions: google.maps.CircleOptions | undefined = undefined;
+	export let markerOptions: google.maps.MarkerOptions | undefined = undefined;
+	export let polygonOptions: google.maps.PolygonOptions | undefined = undefined;
+	export let polylineOptions: google.maps.PolylineOptions | undefined = undefined;
+	export let rectangleOptions: google.maps.RectangleOptions | undefined = undefined;
+	export let drawingControl: boolean = true;
+
+	export let onCircleComplete: ((circle: google.maps.Circle) => void) | undefined = undefined;
+	export let onMarkerComplete: ((marker: google.maps.Marker) => void) | undefined = undefined;
+	export let onOverlayComplete: ((event: google.maps.drawing.OverlayCompleteEvent) => void) | undefined = undefined;
+	export let onPolygonComplete: ((polygon: google.maps.Polygon) => void) | undefined = undefined;
+	export let onPolylineComplete: ((polyline: google.maps.Polyline) => void) | undefined = undefined;
+	export let onRectangleComplete: ((rectangle: google.maps.Rectangle) => void) | undefined = undefined;
+	export let onDrawingModeChange: (() => void) | undefined = undefined;
+	export let onLoad: ((drawingManager: google.maps.drawing.DrawingManager) => void) | undefined = undefined;
+	export let onUnmount: ((drawingManager: google.maps.drawing.DrawingManager) => void) | undefined = undefined;
+
+	let circleCompleteListener: google.maps.MapsEventListener | undefined = undefined;
+	let markerCompleteListener: google.maps.MapsEventListener | undefined = undefined;
+	let overlayCompleteListener: google.maps.MapsEventListener | undefined = undefined;
+	let polygonCompleteListener: google.maps.MapsEventListener | undefined = undefined;
+	let polylineCompleteListener: google.maps.MapsEventListener | undefined = undefined;
+	let rectangleCompleteListener: google.maps.MapsEventListener | undefined = undefined;
+	let drawingModeChangeListener: google.maps.MapsEventListener | undefined = undefined;
+
+	let drawingManager: google.maps.drawing.DrawingManager | null = null;
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	$: if ($status === 'loaded' && googleMapsApi && map && !drawingManager) {
+		drawingManager = new googleMapsApi.drawing.DrawingManager({
+			map: map,
+			drawingMode,
+			drawingControl,
+			drawingControlOptions,
+			circleOptions,
+			markerOptions,
+			polygonOptions,
+			polylineOptions,
+			rectangleOptions
+		});
+		onLoad?.(drawingManager);
+	}
+
+	onDestroy(() => {
+		if (drawingManager) {
+			if (googleMapsApi) {
+				googleMapsApi.event.clearInstanceListeners(drawingManager);
+			}
+			drawingManager.setMap(null);
+			onUnmount?.(drawingManager);
+			drawingManager = null;
+		}
+	});
+
+	$: if (drawingManager && drawingMode !== undefined) {
+		drawingManager.setDrawingMode(drawingMode);
+	}
+
+	$: if (drawingManager) {
+		drawingManager.setOptions({
+			drawingControl,
+			drawingControlOptions,
+			circleOptions,
+			markerOptions,
+			polygonOptions,
+			polylineOptions,
+			rectangleOptions
+		});
+	}
+
+	$: if (drawingManager && onCircleComplete && googleMapsApi && browser) {
+		if (circleCompleteListener) googleMapsApi.event.removeListener(circleCompleteListener);
+		circleCompleteListener = googleMapsApi.event.addListener(
+			drawingManager,
+			'circlecomplete',
+			onCircleComplete
+		);
+	} else if (circleCompleteListener && googleMapsApi) {
+		googleMapsApi.event.removeListener(circleCompleteListener);
+		circleCompleteListener = undefined;
+	}
+
+	$: if (drawingManager && onMarkerComplete && googleMapsApi && browser) {
+		if (markerCompleteListener) googleMapsApi.event.removeListener(markerCompleteListener);
+		markerCompleteListener = googleMapsApi.event.addListener(
+			drawingManager,
+			'markercomplete',
+			onMarkerComplete
+		);
+	} else if (markerCompleteListener && googleMapsApi) {
+		googleMapsApi.event.removeListener(markerCompleteListener);
+		markerCompleteListener = undefined;
+	}
+
+	$: if (drawingManager && onOverlayComplete && googleMapsApi && browser) {
+		if (overlayCompleteListener) googleMapsApi.event.removeListener(overlayCompleteListener);
+		overlayCompleteListener = googleMapsApi.event.addListener(
+			drawingManager,
+			'overlaycomplete',
+			onOverlayComplete
+		);
+	} else if (overlayCompleteListener && googleMapsApi) {
+		googleMapsApi.event.removeListener(overlayCompleteListener);
+		overlayCompleteListener = undefined;
+	}
+
+	$: if (drawingManager && onPolygonComplete && googleMapsApi && browser) {
+		if (polygonCompleteListener) googleMapsApi.event.removeListener(polygonCompleteListener);
+		polygonCompleteListener = googleMapsApi.event.addListener(
+			drawingManager,
+			'polygoncomplete',
+			onPolygonComplete
+		);
+	} else if (polygonCompleteListener && googleMapsApi) {
+		googleMapsApi.event.removeListener(polygonCompleteListener);
+		polygonCompleteListener = undefined;
+	}
+
+	$: if (drawingManager && onPolylineComplete && googleMapsApi && browser) {
+		if (polylineCompleteListener) googleMapsApi.event.removeListener(polylineCompleteListener);
+		polylineCompleteListener = googleMapsApi.event.addListener(
+			drawingManager,
+			'polylinecomplete',
+			onPolylineComplete
+		);
+	} else if (polylineCompleteListener && googleMapsApi) {
+		googleMapsApi.event.removeListener(polylineCompleteListener);
+		polylineCompleteListener = undefined;
+	}
+
+	$: if (drawingManager && onRectangleComplete && googleMapsApi && browser) {
+		if (rectangleCompleteListener) googleMapsApi.event.removeListener(rectangleCompleteListener);
+		rectangleCompleteListener = googleMapsApi.event.addListener(
+			drawingManager,
+			'rectanglecomplete',
+			onRectangleComplete
+		);
+	} else if (rectangleCompleteListener && googleMapsApi) {
+		googleMapsApi.event.removeListener(rectangleCompleteListener);
+		rectangleCompleteListener = undefined;
+	}
+
+	$: if (drawingManager && onDrawingModeChange && googleMapsApi && browser) {
+		if (drawingModeChangeListener) googleMapsApi.event.removeListener(drawingModeChangeListener);
+		drawingModeChangeListener = googleMapsApi.event.addListener(
+			drawingManager,
+			'drawingmode_changed',
+			onDrawingModeChange
+		);
+	} else if (drawingModeChangeListener && googleMapsApi) {
+		googleMapsApi.event.removeListener(drawingModeChangeListener);
+		drawingModeChangeListener = undefined;
+	}
+
+	export function getDrawingManagerInstance(): google.maps.drawing.DrawingManager | null {
+		return drawingManager;
+	}
+</script>
+
+<!-- DrawingManager does not render anything itself, it just controls the Google Maps DrawingManager object -->

--- a/packages/svelte-google-maps-api/src/lib/GoogleMarkerClusterer.svelte
+++ b/packages/svelte-google-maps-api/src/lib/GoogleMarkerClusterer.svelte
@@ -1,0 +1,94 @@
+<script context="module" lang="ts">
+	import type { MarkerClustererOptions as BaseMarkerClustererOptions } from '@googlemaps/markerclusterer';
+
+	export type MarkerClustererOptionsSubset = Omit<BaseMarkerClustererOptions, 'map' | 'markers'>;
+</script>
+
+<script lang="ts">
+	import { getContext, onDestroy, setContext } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import {
+		MarkerClusterer as GoogleMapsMarkerClusterer,
+		type Marker,
+		type MarkerClustererOptions
+	} from '@googlemaps/markerclusterer';
+	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { MarkerClustererContext } from './types/markerClusterer.js';
+
+	export let options: MarkerClustererOptionsSubset = {};
+	export let markers: Marker[] = [];
+	export let onClusterClick: MarkerClustererOptions['onClusterClick'] | undefined = undefined;
+	export let onLoad: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+	export let onUnmount: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+
+	let markerClusterer: GoogleMapsMarkerClusterer | null = null;
+	let registeredMarkers = new Set<Marker>();
+
+	const { status } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	function getClustererOptions(): MarkerClustererOptions {
+		return {
+			...options,
+			map,
+			...(onClusterClick ? { onClusterClick } : {})
+		};
+	}
+
+	function addMarker(marker: Marker) {
+		if (!markerClusterer || registeredMarkers.has(marker)) return;
+		registeredMarkers.add(marker);
+		markerClusterer.addMarker(marker, true);
+		markerClusterer.render();
+	}
+
+	function removeMarker(marker: Marker) {
+		if (!markerClusterer || !registeredMarkers.has(marker)) return;
+		markerClusterer.removeMarker(marker, true);
+		registeredMarkers.delete(marker);
+		markerClusterer.render();
+	}
+
+	setContext<MarkerClustererContext>('markerClusterer', {
+		addMarker,
+		removeMarker
+	});
+
+	function syncMarkers(nextMarkers: Marker[]) {
+		if (!markerClusterer) return;
+
+		for (const marker of Array.from(registeredMarkers)) {
+			if (!nextMarkers.includes(marker)) {
+				removeMarker(marker);
+			}
+		}
+
+		nextMarkers.forEach(addMarker);
+	}
+
+	$: if ($status === 'loaded' && map && !markerClusterer && browser) {
+		markerClusterer = new GoogleMapsMarkerClusterer(getClustererOptions());
+		syncMarkers(markers);
+		onLoad?.(markerClusterer);
+	}
+
+	$: if (markerClusterer && markers) {
+		syncMarkers(markers);
+	}
+
+	onDestroy(() => {
+		if (markerClusterer) {
+			onUnmount?.(markerClusterer);
+			markerClusterer.clearMarkers(true);
+			markerClusterer.setMap(null);
+			registeredMarkers.clear();
+			markerClusterer = null;
+		}
+	});
+</script>
+
+{#if markerClusterer}
+	<slot {markerClusterer} />
+{/if}

--- a/packages/svelte-google-maps-api/src/lib/GroundOverlay.svelte
+++ b/packages/svelte-google-maps-api/src/lib/GroundOverlay.svelte
@@ -56,13 +56,12 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onClick: 'click',
-			onDblClick: 'dblclick'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['dblclick', onDblClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(overlayInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/InfoBox.svelte
+++ b/packages/svelte-google-maps-api/src/lib/InfoBox.svelte
@@ -1,0 +1,370 @@
+<script context="module" lang="ts">
+	type Anchor = google.maps.MVCObject;
+
+	export type InfoBoxOptions = {
+		alignBottom?: boolean;
+		boxClass?: string;
+		boxStyle?: Partial<CSSStyleDeclaration>;
+		closeBoxMargin?: string;
+		closeBoxURL?: string;
+		content?: string | Node;
+		disableAutoPan?: boolean;
+		enableEventPropagation?: boolean;
+		infoBoxClearance?: google.maps.Size;
+		isHidden?: boolean;
+		maxWidth?: number;
+		pane?: keyof google.maps.MapPanes;
+		pixelOffset?: google.maps.Size;
+		position?: google.maps.LatLng;
+		visible?: boolean;
+		zIndex?: number;
+	};
+
+	export type InfoBoxInstance = google.maps.OverlayView & {
+		close: () => void;
+		getContent: () => string | Node | undefined;
+		getPosition: () => google.maps.LatLng | undefined;
+		getVisible: () => boolean;
+		getZIndex: () => number | undefined;
+		hide: () => void;
+		open: (map: google.maps.Map | google.maps.StreetViewPanorama, anchor?: Anchor) => void;
+		panBox: () => void;
+		setContent: (content: string | Node | undefined) => void;
+		setOptions: (options?: InfoBoxOptions) => void;
+		setPosition: (position: google.maps.LatLng) => void;
+		setVisible: (isVisible: boolean) => void;
+		setZIndex: (zIndex: number) => void;
+		show: () => void;
+	};
+</script>
+
+<script lang="ts">
+	import { getContext, onDestroy, onMount, tick } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from './APIProvider.svelte';
+
+	export let anchor: Anchor | undefined = undefined;
+	export let options: InfoBoxOptions | undefined = undefined;
+	export let position: google.maps.LatLng | google.maps.LatLngLiteral | undefined = undefined;
+	export let zIndex: number | undefined = undefined;
+	export let isOpen = true;
+
+	export let onCloseClick: (() => void) | undefined = undefined;
+	export let onDomReady: (() => void) | undefined = undefined;
+	export let onContentChanged: (() => void) | undefined = undefined;
+	export let onPositionChanged: (() => void) | undefined = undefined;
+	export let onZindexChanged: (() => void) | undefined = undefined;
+	export let onLoad: ((infoBox: InfoBoxInstance) => void) | undefined = undefined;
+	export let onUnmount: ((infoBox: InfoBoxInstance) => void) | undefined = undefined;
+
+	let infoBoxInstance: InfoBoxInstance | null = null;
+	let contentWrapper: HTMLDivElement | null = null;
+	let listeners: google.maps.MapsEventListener[] = [];
+	let listenerDeps: unknown[] = [];
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	onMount(() => {
+		tick().then(initializeInfoBox);
+	});
+
+	function toLatLng(
+		nextPosition: google.maps.LatLng | google.maps.LatLngLiteral | undefined
+	): google.maps.LatLng | undefined {
+		if (!nextPosition || !googleMapsApi) return undefined;
+		if (nextPosition instanceof googleMapsApi.LatLng) return nextPosition;
+		return new googleMapsApi.LatLng(nextPosition.lat, nextPosition.lng);
+	}
+
+	function createInfoBox(initialOptions: InfoBoxOptions): InfoBoxInstance {
+		if (!googleMapsApi) {
+			throw new Error('[InfoBox] Google Maps API is not loaded.');
+		}
+
+		const mapsApi = googleMapsApi;
+		const overlay = new mapsApi.OverlayView() as InfoBoxInstance;
+		const state = {
+			alignBottom: false,
+			boxClass: 'infoBox',
+			boxStyle: {} as Partial<CSSStyleDeclaration>,
+			closeBoxMargin: '2px',
+			closeBoxURL: 'https://www.google.com/intl/en_us/mapfiles/close.gif',
+			content: '' as string | Node | undefined,
+			domListeners: [] as Array<() => void>,
+			enableEventPropagation: false,
+			isVisible: true,
+			maxWidth: 0,
+			paneName: 'floatPane' as keyof google.maps.MapPanes,
+			pixelOffset: new mapsApi.Size(0, 0),
+			positionValue: undefined as google.maps.LatLng | undefined,
+			zIndexValue: undefined as number | undefined,
+			container: document.createElement('div')
+		};
+
+		state.container.style.position = 'absolute';
+
+		function getAnchorPosition(nextAnchor: Anchor | undefined): google.maps.LatLng | undefined {
+			if (!nextAnchor) return undefined;
+
+			const anchorWithPosition = nextAnchor as Anchor & {
+				getPosition?: () => google.maps.LatLng | undefined;
+				position?: google.maps.LatLng | google.maps.LatLngLiteral;
+			};
+			const nextPosition = anchorWithPosition.getPosition?.() ?? anchorWithPosition.position;
+
+			return toLatLng(nextPosition);
+		}
+
+		function preventMapEventPropagation() {
+			const events = [
+				'click',
+				'contextmenu',
+				'dblclick',
+				'mousedown',
+				'mousemove',
+				'mouseout',
+				'mouseover',
+				'mouseup',
+				'touchend',
+				'touchstart'
+			];
+
+			events.forEach((eventName) => {
+				const handler = (event: Event) => event.stopPropagation();
+				state.container.addEventListener(eventName, handler);
+				state.domListeners.push(() => state.container.removeEventListener(eventName, handler));
+			});
+		}
+
+		function render() {
+			state.domListeners.forEach((removeListener) => removeListener());
+			state.domListeners = [];
+			state.container.replaceChildren();
+			state.container.className = state.boxClass;
+			state.container.style.cssText = 'position:absolute;';
+			state.container.style.display = state.isVisible ? '' : 'none';
+			if (state.maxWidth > 0) state.container.style.maxWidth = `${state.maxWidth}px`;
+			if (state.zIndexValue !== undefined) {
+				state.container.style.zIndex = String(state.zIndexValue);
+			}
+			Object.assign(state.container.style, state.boxStyle);
+
+			if (!state.enableEventPropagation) {
+				preventMapEventPropagation();
+			}
+
+			if (state.closeBoxURL !== '') {
+				const closeButton = document.createElement('img');
+				closeButton.alt = 'Close';
+				closeButton.src = state.closeBoxURL;
+				closeButton.style.cssText = `cursor:pointer;float:right;margin:${state.closeBoxMargin};`;
+				closeButton.addEventListener('click', (event) => {
+					event.stopPropagation();
+					mapsApi.event.trigger(overlay, 'closeclick');
+					overlay.close();
+				});
+				state.container.appendChild(closeButton);
+			}
+
+			if (typeof state.content === 'string') {
+				const contentElement = document.createElement('div');
+				contentElement.innerHTML = state.content;
+				state.container.appendChild(contentElement);
+			} else if (state.content) {
+				state.container.appendChild(state.content);
+			}
+		}
+
+		overlay.onAdd = () => {
+			const pane = overlay.getPanes()?.[state.paneName];
+			if (!pane) return;
+
+			render();
+			pane.appendChild(state.container);
+			mapsApi.event.trigger(overlay, 'domready');
+		};
+
+		overlay.draw = () => {
+			const projection = overlay.getProjection();
+			if (!projection || !state.positionValue) return;
+
+			const point = projection.fromLatLngToDivPixel(state.positionValue);
+			if (!point) return;
+
+			state.container.style.left = `${point.x + state.pixelOffset.width}px`;
+			state.container.style.top = `${
+				point.y + state.pixelOffset.height - (state.alignBottom ? state.container.offsetHeight : 0)
+			}px`;
+		};
+
+		overlay.onRemove = () => {
+			state.domListeners.forEach((removeListener) => removeListener());
+			state.domListeners = [];
+
+			if (state.container.parentNode) {
+				state.container.parentNode.removeChild(state.container);
+			}
+		};
+
+		overlay.close = () => overlay.setMap(null);
+		overlay.getContent = () => state.content;
+		overlay.getPosition = () => state.positionValue;
+		overlay.getVisible = () => state.isVisible;
+		overlay.getZIndex = () => state.zIndexValue;
+		overlay.hide = () => overlay.setVisible(false);
+		overlay.open = (nextMap, nextAnchor) => {
+			const anchorPosition = getAnchorPosition(nextAnchor);
+			if (anchorPosition) {
+				overlay.setPosition(anchorPosition);
+			}
+
+			overlay.setMap(nextMap);
+		};
+		overlay.panBox = () => undefined;
+		overlay.setContent = (nextContent) => {
+			state.content = nextContent;
+			render();
+			mapsApi.event.trigger(overlay, 'content_changed');
+		};
+		overlay.setOptions = (nextOptions: InfoBoxOptions = {}) => {
+			if (nextOptions.alignBottom !== undefined) state.alignBottom = nextOptions.alignBottom;
+			if (nextOptions.boxClass !== undefined) state.boxClass = nextOptions.boxClass;
+			if (nextOptions.boxStyle !== undefined) state.boxStyle = nextOptions.boxStyle;
+			if (nextOptions.closeBoxMargin !== undefined)
+				state.closeBoxMargin = nextOptions.closeBoxMargin;
+			if (nextOptions.closeBoxURL !== undefined) state.closeBoxURL = nextOptions.closeBoxURL;
+			if (nextOptions.enableEventPropagation !== undefined) {
+				state.enableEventPropagation = nextOptions.enableEventPropagation;
+			}
+			if (nextOptions.maxWidth !== undefined) state.maxWidth = nextOptions.maxWidth;
+			if (nextOptions.pane !== undefined) state.paneName = nextOptions.pane;
+			if (nextOptions.pixelOffset !== undefined) state.pixelOffset = nextOptions.pixelOffset;
+			if (nextOptions.position !== undefined) overlay.setPosition(nextOptions.position);
+			if (nextOptions.visible !== undefined) overlay.setVisible(nextOptions.visible);
+			if (nextOptions.isHidden !== undefined) overlay.setVisible(!nextOptions.isHidden);
+			if (nextOptions.zIndex !== undefined) overlay.setZIndex(nextOptions.zIndex);
+			if (nextOptions.content !== undefined) overlay.setContent(nextOptions.content);
+
+			render();
+			overlay.draw();
+		};
+		overlay.setPosition = (nextPosition) => {
+			state.positionValue = nextPosition;
+			overlay.draw();
+			mapsApi.event.trigger(overlay, 'position_changed');
+		};
+		overlay.setVisible = (nextVisible) => {
+			state.isVisible = nextVisible;
+			state.container.style.display = nextVisible ? '' : 'none';
+		};
+		overlay.setZIndex = (nextZIndex) => {
+			state.zIndexValue = nextZIndex;
+			state.container.style.zIndex = String(nextZIndex);
+			mapsApi.event.trigger(overlay, 'zindex_changed');
+		};
+		overlay.show = () => overlay.setVisible(true);
+
+		overlay.setOptions(initialOptions);
+
+		return overlay;
+	}
+
+	function clearListeners() {
+		if (!googleMapsApi) return;
+		listeners.forEach((listener) => googleMapsApi.event.removeListener(listener));
+		listeners = [];
+	}
+
+	function addListener(eventName: string, handler: (() => void) | undefined) {
+		if (infoBoxInstance && handler && googleMapsApi) {
+			listeners.push(googleMapsApi.event.addListener(infoBoxInstance, eventName, handler));
+		}
+	}
+
+	function setupListeners() {
+		if (!infoBoxInstance || !googleMapsApi) return;
+
+		clearListeners();
+		addListener('closeclick', onCloseClick);
+		addListener('domready', onDomReady);
+		addListener('content_changed', onContentChanged);
+		addListener('position_changed', onPositionChanged);
+		addListener('zindex_changed', onZindexChanged);
+	}
+
+	function openInfoBox() {
+		if (!infoBoxInstance || !map) return;
+
+		if (!isOpen) {
+			infoBoxInstance.close();
+			return;
+		}
+
+		if (anchor) {
+			infoBoxInstance.open(map, anchor);
+		} else if (infoBoxInstance.getPosition()) {
+			infoBoxInstance.open(map);
+		}
+	}
+
+	function initializeInfoBox() {
+		if (!browser || $status !== 'loaded' || !googleMapsApi || !map || infoBoxInstance) return;
+
+		infoBoxInstance = createInfoBox({
+			...(options ?? {}),
+			content: contentWrapper ?? options?.content,
+			position: toLatLng(position ?? options?.position),
+			zIndex: zIndex ?? options?.zIndex
+		});
+		setupListeners();
+		openInfoBox();
+		onLoad?.(infoBoxInstance);
+	}
+
+	$: if ($status === 'loaded' && !infoBoxInstance) {
+		tick().then(initializeInfoBox);
+	}
+
+	$: if (infoBoxInstance && options) {
+		infoBoxInstance.setOptions(options);
+	}
+
+	$: if (infoBoxInstance && position) {
+		const nextPosition = toLatLng(position);
+		if (nextPosition) infoBoxInstance.setPosition(nextPosition);
+	}
+
+	$: if (infoBoxInstance && zIndex !== undefined) {
+		infoBoxInstance.setZIndex(zIndex);
+	}
+
+	$: listenerDeps = [
+		onCloseClick,
+		onDomReady,
+		onContentChanged,
+		onPositionChanged,
+		onZindexChanged
+	];
+
+	$: if (infoBoxInstance && googleMapsApi && browser && listenerDeps) {
+		setupListeners();
+	}
+
+	$: if (infoBoxInstance && map) {
+		openInfoBox();
+	}
+
+	onDestroy(() => {
+		if (infoBoxInstance) {
+			clearListeners();
+			onUnmount?.(infoBoxInstance);
+			infoBoxInstance.close();
+			infoBoxInstance = null;
+		}
+	});
+</script>
+
+<div bind:this={contentWrapper}>
+	<slot />
+</div>

--- a/packages/svelte-google-maps-api/src/lib/InfoWindow.svelte
+++ b/packages/svelte-google-maps-api/src/lib/InfoWindow.svelte
@@ -138,7 +138,7 @@
 
 	function updateOpenState() {
 		if (!infoWindowInstance || !map) return;
-
+		console.log('updateOpenState', internalOpenState);
 		if (internalOpenState) {
 			let openAnchor: google.maps.MVCObject | undefined = undefined;
 			if (anchor && typeof anchor === 'object' && anchor !== null) {
@@ -161,17 +161,12 @@
 	}
 </script>
 
-<!-- Wrapper for slot content -->
 <div bind:this={contentWrapper}>
 	<slot />
 </div>
 
-<!-- Wrapper for header slot content (optional) -->
 {#if $$slots.header}
 	<div bind:this={headerWrapper}>
 		<slot name="header" />
 	</div>
 {/if}
-
-<!-- This component doesn't render directly to the DOM where it's used,
-     it controls the InfoWindow on the map -->

--- a/packages/svelte-google-maps-api/src/lib/Marker.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Marker.svelte
@@ -2,6 +2,7 @@
 	import { getContext, onDestroy } from 'svelte';
 	import { BROWSER as browser } from 'esm-env';
 	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { ClusterableMarker, MarkerClustererContext } from './types/markerClusterer.js';
 
 	export let position: google.maps.LatLng | google.maps.LatLngLiteral;
 	export let options: google.maps.MarkerOptions = {};
@@ -53,15 +54,21 @@
 	let zindexChangedListener: google.maps.MapsEventListener | undefined = undefined;
 
 	let marker: google.maps.Marker | null = null;
+	let isClustered = false;
 	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
 	const map = getContext<google.maps.Map>('map');
+	const markerClusterer = getContext<MarkerClustererContext | undefined>('markerClusterer');
 
 	$: if ($status === 'loaded' && googleMapsApi && map && position && !marker) {
 		marker = new googleMapsApi.Marker({
 			position,
-			map: map,
+			...(markerClusterer ? {} : { map }),
 			...options
 		});
+		if (markerClusterer) {
+			markerClusterer.addMarker(marker as ClusterableMarker);
+			isClustered = true;
+		}
 		onLoad?.(marker);
 	}
 
@@ -70,9 +77,14 @@
 			if (googleMapsApi) {
 				googleMapsApi.event.clearInstanceListeners(marker);
 			}
-			marker.setMap(null);
+			if (isClustered && markerClusterer) {
+				markerClusterer.removeMarker(marker as ClusterableMarker);
+			} else {
+				marker.setMap(null);
+			}
 			onUnmount?.(marker);
 			marker = null;
+			isClustered = false;
 		}
 	});
 

--- a/packages/svelte-google-maps-api/src/lib/MarkerClusterer.svelte
+++ b/packages/svelte-google-maps-api/src/lib/MarkerClusterer.svelte
@@ -1,0 +1,109 @@
+<script context="module" lang="ts">
+	import type {
+		Cluster,
+		MarkerClustererOptions as BaseMarkerClustererOptions
+	} from '@googlemaps/markerclusterer';
+
+	export type MarkerClustererOptionsSubset = Omit<BaseMarkerClustererOptions, 'map' | 'markers'>;
+</script>
+
+<script lang="ts">
+	import { getContext, onDestroy, setContext } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import {
+		MarkerClusterer as GoogleMapsMarkerClusterer,
+		type Marker,
+		type MarkerClustererOptions
+	} from '@googlemaps/markerclusterer';
+	import type { APIProviderContext } from './APIProvider.svelte';
+	import type { MarkerClustererContext } from './types/markerClusterer.js';
+
+	export let options: MarkerClustererOptionsSubset = {};
+	export let markers: Marker[] = [];
+	export let onClick: ((cluster: Cluster) => void) | undefined = undefined;
+	export let onClusterClick: MarkerClustererOptions['onClusterClick'] | undefined = undefined;
+	export let onLoad: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+	export let onUnmount: ((markerClusterer: GoogleMapsMarkerClusterer) => void) | undefined =
+		undefined;
+
+	let markerClusterer: GoogleMapsMarkerClusterer | null = null;
+	let registeredMarkers = new Set<Marker>();
+
+	const { status } = getContext<APIProviderContext>('svelte-google-maps-api');
+	const map = getContext<google.maps.Map>('map');
+
+	function getOnClusterClick(): MarkerClustererOptions['onClusterClick'] | undefined {
+		if (onClusterClick) return onClusterClick;
+		if (!onClick) return undefined;
+
+		return ((event: google.maps.MapMouseEvent, cluster: Cluster) => {
+			onClick?.(cluster);
+		}) as MarkerClustererOptions['onClusterClick'];
+	}
+
+	function getClustererOptions(): MarkerClustererOptions {
+		const clusterClick = getOnClusterClick();
+
+		return {
+			...options,
+			map,
+			...(clusterClick ? { onClusterClick: clusterClick } : {})
+		};
+	}
+
+	function addMarker(marker: Marker) {
+		if (!markerClusterer || registeredMarkers.has(marker)) return;
+		registeredMarkers.add(marker);
+		markerClusterer.addMarker(marker, true);
+		markerClusterer.render();
+	}
+
+	function removeMarker(marker: Marker) {
+		if (!markerClusterer || !registeredMarkers.has(marker)) return;
+		markerClusterer.removeMarker(marker, true);
+		registeredMarkers.delete(marker);
+		markerClusterer.render();
+	}
+
+	setContext<MarkerClustererContext>('markerClusterer', {
+		addMarker,
+		removeMarker
+	});
+
+	function syncMarkers(nextMarkers: Marker[]) {
+		if (!markerClusterer) return;
+
+		for (const marker of Array.from(registeredMarkers)) {
+			if (!nextMarkers.includes(marker)) {
+				removeMarker(marker);
+			}
+		}
+
+		nextMarkers.forEach(addMarker);
+	}
+
+	$: if ($status === 'loaded' && map && !markerClusterer && browser) {
+		markerClusterer = new GoogleMapsMarkerClusterer(getClustererOptions());
+		syncMarkers(markers);
+		onLoad?.(markerClusterer);
+	}
+
+	$: if (markerClusterer && markers) {
+		syncMarkers(markers);
+	}
+
+	onDestroy(() => {
+		if (markerClusterer) {
+			onUnmount?.(markerClusterer);
+			markerClusterer.clearMarkers(true);
+			markerClusterer.setMap(null);
+			registeredMarkers.clear();
+			markerClusterer = null;
+		}
+	});
+</script>
+
+{#if markerClusterer}
+	<slot {markerClusterer} />
+{/if}

--- a/packages/svelte-google-maps-api/src/lib/Polygon.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Polygon.svelte
@@ -102,22 +102,21 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(polygonInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/Polyline.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Polyline.svelte
@@ -94,22 +94,21 @@
 			googleMapsApi.event.removeListener(pathUpdateListener);
 			pathUpdateListener = null;
 		}
-		const eventMap = {
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(polylineInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/Rectangle.svelte
+++ b/packages/svelte-google-maps-api/src/lib/Rectangle.svelte
@@ -95,23 +95,22 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onBoundsChanged: 'bounds_changed',
-			onClick: 'click',
-			onDblClick: 'dblclick',
-			onDrag: 'drag',
-			onDragEnd: 'dragend',
-			onDragStart: 'dragstart',
-			onMouseDown: 'mousedown',
-			onMouseMove: 'mousemove',
-			onMouseOut: 'mouseout',
-			onMouseOver: 'mouseover',
-			onMouseUp: 'mouseup',
-			onRightClick: 'rightclick'
-		};
+		const eventHandlers = [
+			['bounds_changed', onBoundsChanged],
+			['click', onClick],
+			['dblclick', onDblClick],
+			['drag', onDrag],
+			['dragend', onDragEnd],
+			['dragstart', onDragStart],
+			['mousedown', onMouseDown],
+			['mousemove', onMouseMove],
+			['mouseout', onMouseOut],
+			['mouseover', onMouseOver],
+			['mouseup', onMouseUp],
+			['rightclick', onRightClick]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(rectangleInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/index.ts
+++ b/packages/svelte-google-maps-api/src/lib/index.ts
@@ -10,14 +10,29 @@ import Rectangle from './Rectangle.svelte';
 import HeatmapLayer from './HeatmapLayer.svelte';
 import GroundOverlay from './GroundOverlay.svelte';
 import DirectionsRenderer from './DirectionsRenderer.svelte';
+import DirectionsService from './DirectionsService.svelte';
+import DistanceMatrixService from './DistanceMatrixService.svelte';
+import DrawingManager from './DrawingManager.svelte';
+import Data from './Data.svelte';
+import MarkerClusterer from './MarkerClusterer.svelte';
+import GoogleMarkerClusterer from './GoogleMarkerClusterer.svelte';
+import InfoBox from './InfoBox.svelte';
 import TrafficLayer from './layers/TrafficLayer.svelte';
 import TransitLayer from './layers/TransitLayer.svelte';
 import BicyclingLayer from './layers/BicyclingLayer.svelte';
 import KmlLayer from './layers/KmlLayer.svelte';
 import Autocomplete from './places/Autocomplete.svelte';
+import StandaloneSearchBox from './places/StandaloneSearchBox.svelte';
 import OverlayView from './overlay/OverlayView.svelte';
 import StreetViewPanorama from './street-view/StreetViewPanorama.svelte';
+import StreetViewService from './street-view/StreetViewService.svelte';
 import MapControl from './controls/MapControl.svelte';
+
+const FLOAT_PANE = 'floatPane';
+const MAP_PANE = 'mapPane';
+const MARKER_LAYER = 'markerLayer';
+const OVERLAY_LAYER = 'overlayLayer';
+const OVERLAY_MOUSE_TARGET = 'overlayMouseTarget';
 
 export {
 	APIProvider,
@@ -29,17 +44,33 @@ export {
 	Polygon,
 	Circle,
 	Rectangle,
+	Data,
 	HeatmapLayer,
 	GroundOverlay,
 	DirectionsRenderer,
+	DirectionsService,
+	DistanceMatrixService,
+	DrawingManager,
+	MarkerClusterer,
+	GoogleMarkerClusterer,
+	InfoBox,
 	TrafficLayer,
 	TransitLayer,
 	BicyclingLayer,
 	KmlLayer,
 	Autocomplete,
+	StandaloneSearchBox,
 	OverlayView,
 	StreetViewPanorama,
-	MapControl
+	StreetViewService,
+	MapControl,
+	FLOAT_PANE,
+	MAP_PANE,
+	MARKER_LAYER,
+	OVERLAY_LAYER,
+	OVERLAY_MOUSE_TARGET
 };
 
 export * from './types/googleMap.js';
+export * from './types/markerClusterer.js';
+export * as GoogleMapsMarkerClusterer from '@googlemaps/markerclusterer';

--- a/packages/svelte-google-maps-api/src/lib/layers/KmlLayer.svelte
+++ b/packages/svelte-google-maps-api/src/lib/layers/KmlLayer.svelte
@@ -63,6 +63,7 @@
 		layerInstance = null;
 	}
 	$: if (layerInstance && options) {
+		layerInstance.setOptions(options);
 	}
 
 	function setupListeners() {
@@ -71,14 +72,13 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onClick: 'click',
-			onDefaultViewportChanged: 'defaultviewport_changed',
-			onStatusChanged: 'status_changed'
-		};
+		const eventHandlers = [
+			['click', onClick],
+			['defaultviewport_changed', onDefaultViewportChanged],
+			['status_changed', onStatusChanged]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(layerInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/places/Autocomplete.svelte
+++ b/packages/svelte-google-maps-api/src/lib/places/Autocomplete.svelte
@@ -10,6 +10,7 @@
 	export let placeholder: string | undefined = undefined;
 	export let inputId: string | undefined = undefined;
 	export let inputClass: string = '';
+	export let className: string = '';
 	export let inputStyle: string = '';
 	export let disabled: boolean = false;
 
@@ -17,11 +18,13 @@
 		undefined;
 	export let componentRestrictions: google.maps.places.ComponentRestrictions | undefined =
 		undefined;
+	export let restrictions: google.maps.places.ComponentRestrictions | undefined = undefined;
 	export let fields: string[] | undefined = undefined;
 	export let strictBounds: boolean | undefined = undefined;
 	export let types: string[] | undefined = undefined;
 
 	const dispatch = createEventDispatcher<{ place_changed: google.maps.places.PlaceResult }>();
+	export let onPlaceChanged: (() => void) | undefined = undefined;
 	export let onLoad: ((autocomplete: google.maps.places.Autocomplete) => void) | undefined =
 		undefined;
 	export let onUnmount: ((autocomplete: google.maps.places.Autocomplete) => void) | undefined =
@@ -80,7 +83,7 @@
 		const autocompleteOptions: google.maps.places.AutocompleteOptions = {
 			...(options ?? {}),
 			bounds,
-			componentRestrictions,
+			componentRestrictions: componentRestrictions ?? restrictions,
 			fields,
 			strictBounds,
 			types
@@ -109,8 +112,8 @@
 	} else if (autocompleteInstance) {
 		const individualOptions: google.maps.places.AutocompleteOptions = {};
 		if (bounds !== undefined) individualOptions.bounds = bounds;
-		if (componentRestrictions !== undefined)
-			individualOptions.componentRestrictions = componentRestrictions;
+		if (componentRestrictions !== undefined || restrictions !== undefined)
+			individualOptions.componentRestrictions = componentRestrictions ?? restrictions;
 		if (fields !== undefined) individualOptions.fields = fields;
 		if (strictBounds !== undefined) individualOptions.strictBounds = strictBounds;
 		if (types !== undefined) individualOptions.types = types;
@@ -131,6 +134,7 @@
 				if (inputElement && place.name) {
 					value = place.name;
 				}
+				onPlaceChanged?.();
 				dispatch('place_changed', place);
 			}
 		});
@@ -169,6 +173,6 @@
 	{placeholder}
 	{disabled}
 	id={inputId}
-	class="svelte-google-maps-autocomplete {inputClass}"
+	class="svelte-google-maps-autocomplete {inputClass} {className}"
 	style={inputStyle}
 />

--- a/packages/svelte-google-maps-api/src/lib/places/StandaloneSearchBox.svelte
+++ b/packages/svelte-google-maps-api/src/lib/places/StandaloneSearchBox.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { createEventDispatcher, getContext, onDestroy, onMount, tick } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from '../APIProvider.svelte';
+
+	export let bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral | undefined =
+		undefined;
+	export let options: google.maps.places.SearchBoxOptions | undefined = undefined;
+
+	export let value: string = '';
+	export let placeholder: string | undefined = undefined;
+	export let inputId: string | undefined = undefined;
+	export let inputClass: string = '';
+	export let inputStyle: string = '';
+	export let disabled: boolean = false;
+
+	export let onPlacesChanged: ((places: google.maps.places.PlaceResult[] | undefined) => void) | undefined =
+		undefined;
+	export let onLoad: ((searchBox: google.maps.places.SearchBox) => void) | undefined = undefined;
+	export let onUnmount: ((searchBox: google.maps.places.SearchBox) => void) | undefined =
+		undefined;
+
+	const dispatch = createEventDispatcher<{
+		places_changed: google.maps.places.PlaceResult[] | undefined;
+	}>();
+
+	let containerElement: HTMLDivElement | null = null;
+	let inputElement: HTMLInputElement | null = null;
+	let searchBoxInstance: google.maps.places.SearchBox | null = null;
+	let placesChangedListener: google.maps.MapsEventListener | null = null;
+	let isMounted = false;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	onMount(() => {
+		isMounted = true;
+		tick().then(initializeSearchBox);
+	});
+
+	function getInputElement() {
+		return inputElement ?? containerElement?.querySelector('input') ?? null;
+	}
+
+	function initializeSearchBox() {
+		if (!browser || $status !== 'loaded' || !googleMapsApi || searchBoxInstance || !isMounted) {
+			return;
+		}
+
+		if (!googleMapsApi.places || !googleMapsApi.places.SearchBox) {
+			console.error(
+				'svelte-google-maps-api: StandaloneSearchBox requires the "places" library. Please include "places" in the libraries prop of APIProvider.'
+			);
+			return;
+		}
+
+		const input = getInputElement();
+		if (!input) return;
+
+		searchBoxInstance = new googleMapsApi.places.SearchBox(input, options);
+
+		if (bounds !== undefined) {
+			searchBoxInstance.setBounds(bounds);
+		}
+
+		setupListeners();
+		onLoad?.(searchBoxInstance);
+	}
+
+	function setupListeners() {
+		if (!searchBoxInstance || !googleMapsApi) return;
+
+		if (placesChangedListener) {
+			googleMapsApi.event.removeListener(placesChangedListener);
+			placesChangedListener = null;
+		}
+
+		placesChangedListener = searchBoxInstance.addListener('places_changed', () => {
+			const places = searchBoxInstance?.getPlaces();
+			onPlacesChanged?.(places);
+			dispatch('places_changed', places);
+		});
+	}
+
+	$: if ($status === 'loaded' && !searchBoxInstance) {
+		tick().then(initializeSearchBox);
+	}
+
+	$: if (searchBoxInstance && bounds !== undefined) {
+		searchBoxInstance.setBounds(bounds);
+	}
+
+	$: if (searchBoxInstance && googleMapsApi && browser && onPlacesChanged) {
+		setupListeners();
+	}
+
+	onDestroy(() => {
+		if (searchBoxInstance && googleMapsApi) {
+			onUnmount?.(searchBoxInstance);
+			if (placesChangedListener) {
+				googleMapsApi.event.removeListener(placesChangedListener);
+			}
+			googleMapsApi.event.clearInstanceListeners(searchBoxInstance);
+			searchBoxInstance = null;
+		}
+	});
+</script>
+
+<div bind:this={containerElement} class="svelte-google-maps-search-box">
+	{#if $$slots.default}
+		<slot />
+	{:else}
+		<input
+			bind:this={inputElement}
+			bind:value
+			{placeholder}
+			{disabled}
+			id={inputId}
+			class="svelte-google-maps-search-box-input {inputClass}"
+			style={inputStyle}
+		/>
+	{/if}
+</div>

--- a/packages/svelte-google-maps-api/src/lib/street-view/StreetViewPanorama.svelte
+++ b/packages/svelte-google-maps-api/src/lib/street-view/StreetViewPanorama.svelte
@@ -134,19 +134,18 @@
 		listeners.forEach((listener) => googleMapsApi?.event.removeListener(listener));
 		listeners = [];
 
-		const eventMap = {
-			onCloseClick: 'closeclick',
-			onPanoChanged: 'pano_changed',
-			onPositionChanged: 'position_changed',
-			onPovChanged: 'pov_changed',
-			onResize: 'resize',
-			onStatusChanged: 'status_changed',
-			onVisibleChanged: 'visible_changed',
-			onZoomChanged: 'zoom_changed'
-		};
+		const eventHandlers = [
+			['closeclick', onCloseClick],
+			['pano_changed', onPanoChanged],
+			['position_changed', onPositionChanged],
+			['pov_changed', onPovChanged],
+			['resize', onResize],
+			['status_changed', onStatusChanged],
+			['visible_changed', onVisibleChanged],
+			['zoom_changed', onZoomChanged]
+		] as const;
 
-		Object.entries(eventMap).forEach(([propName, eventName]) => {
-			const callback = $$props[propName];
+		eventHandlers.forEach(([eventName, callback]) => {
 			if (callback) {
 				listeners.push(panoramaInstance!.addListener(eventName, callback));
 			}

--- a/packages/svelte-google-maps-api/src/lib/street-view/StreetViewService.svelte
+++ b/packages/svelte-google-maps-api/src/lib/street-view/StreetViewService.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { getContext, onDestroy } from 'svelte';
+	import { BROWSER as browser } from 'esm-env';
+	import type { APIProviderContext } from '../APIProvider.svelte';
+
+	export let onLoad: ((streetViewService: google.maps.StreetViewService) => void) | undefined =
+		undefined;
+	export let onUnmount: ((streetViewService: google.maps.StreetViewService) => void) | undefined =
+		undefined;
+
+	let streetViewService: google.maps.StreetViewService | null = null;
+
+	const { status, googleMapsApi } = getContext<APIProviderContext>('svelte-google-maps-api');
+
+	$: if ($status === 'loaded' && googleMapsApi && !streetViewService && browser) {
+		streetViewService = new googleMapsApi.StreetViewService();
+		onLoad?.(streetViewService);
+	}
+
+	onDestroy(() => {
+		if (streetViewService) {
+			onUnmount?.(streetViewService);
+			streetViewService = null;
+		}
+	});
+</script>

--- a/packages/svelte-google-maps-api/src/lib/types/googleMap.ts
+++ b/packages/svelte-google-maps-api/src/lib/types/googleMap.ts
@@ -7,3 +7,5 @@ export type Library =
 	| 'places'
 	| 'routes'
 	| 'visualization';
+
+export type Libraries = Library[];

--- a/packages/svelte-google-maps-api/src/lib/types/markerClusterer.ts
+++ b/packages/svelte-google-maps-api/src/lib/types/markerClusterer.ts
@@ -1,0 +1,8 @@
+import type { Marker } from '@googlemaps/markerclusterer';
+
+export interface MarkerClustererContext {
+	addMarker: (marker: Marker) => void;
+	removeMarker: (marker: Marker) => void;
+}
+
+export type ClusterableMarker = Marker;

--- a/packages/svelte-google-maps-api/src/lib/utils/preventGoogleFonts.ts
+++ b/packages/svelte-google-maps-api/src/lib/utils/preventGoogleFonts.ts
@@ -1,0 +1,60 @@
+function isGoogleFontStyle(element: Node): boolean {
+	const href = (element as HTMLLinkElement).href;
+
+	if (
+		href &&
+		(href.indexOf('https://fonts.googleapis.com/css?family=Roboto') === 0 ||
+			href.indexOf('https://fonts.googleapis.com/css?family=Google+Sans+Text') === 0)
+	) {
+		return true;
+	}
+
+	const tagName = (element as HTMLElement).tagName?.toLowerCase();
+	if (tagName !== 'style') return false;
+
+	const styleElement = element as HTMLStyleElement & {
+		styleSheet?: { cssText?: string };
+	};
+	const styleSheetText = styleElement.styleSheet?.cssText;
+
+	if (styleSheetText && styleSheetText.replace('\r\n', '').indexOf('.gm-style') === 0) {
+		styleElement.styleSheet!.cssText = '';
+		return true;
+	}
+
+	if (
+		styleElement.innerHTML &&
+		styleElement.innerHTML.replace('\r\n', '').indexOf('.gm-style') === 0
+	) {
+		styleElement.innerHTML = '';
+		return true;
+	}
+
+	return !styleElement.styleSheet && !styleElement.innerHTML;
+}
+
+export function preventGoogleFonts(): void {
+	const head = document.getElementsByTagName('head')[0];
+	if (!head) return;
+
+	const trueInsertBefore = head.insertBefore.bind(head);
+	head.insertBefore = function insertBefore<T extends Node>(
+		newElement: T,
+		referenceElement: Node | null
+	): T {
+		if (!isGoogleFontStyle(newElement)) {
+			Reflect.apply(trueInsertBefore, head, [newElement, referenceElement]);
+		}
+
+		return newElement;
+	};
+
+	const trueAppend = head.appendChild.bind(head);
+	head.appendChild = function appendChild<T extends Node>(newElement: T): T {
+		if (!isGoogleFontStyle(newElement)) {
+			Reflect.apply(trueAppend, head, [newElement]);
+		}
+
+		return newElement;
+	};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^0.32.2
-        version: 0.32.4(terser@5.39.0)
+        version: 0.32.4(jsdom@26.1.0)(terser@5.39.0)
 
   apps/docs:
     dependencies:
@@ -76,6 +76,73 @@ importers:
         specifier: ^5.0.3
         version: 5.4.19(@types/node@20.17.32)(terser@5.39.0)
 
+  apps/examples:
+    dependencies:
+      svelte-google-maps-api:
+        specifier: workspace:*
+        version: link:../../packages/svelte-google-maps-api
+    devDependencies:
+      '@eslint/compat':
+        specifier: ^1.2.5
+        version: 1.2.9(eslint@9.26.0(jiti@1.21.7))
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.26.0
+      '@sveltejs/adapter-auto':
+        specifier: ^6.0.0
+        version: 6.0.0(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))
+      '@sveltejs/kit':
+        specifier: ^2.16.0
+        version: 2.20.8(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
+      '@testing-library/svelte':
+        specifier: ^5.2.4
+        version: 5.2.7(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      eslint:
+        specifier: ^9.18.0
+        version: 9.26.0(jiti@1.21.7)
+      eslint-config-prettier:
+        specifier: ^10.0.1
+        version: 10.1.2(eslint@9.26.0(jiti@1.21.7))
+      eslint-plugin-svelte:
+        specifier: ^3.0.0
+        version: 3.5.1(eslint@9.26.0(jiti@1.21.7))(svelte@5.28.2)
+      globals:
+        specifier: ^16.0.0
+        version: 16.0.0
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
+      prettier:
+        specifier: ^3.4.2
+        version: 3.5.3
+      prettier-plugin-svelte:
+        specifier: ^3.3.3
+        version: 3.3.3(prettier@3.5.3)(svelte@5.28.2)
+      svelte:
+        specifier: ^5.28.2
+        version: 5.28.2
+      svelte-check:
+        specifier: ^4.0.0
+        version: 4.1.7(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.20.0
+        version: 8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
   packages/svelte-google-maps-api:
     dependencies:
       esm-env:
@@ -105,6 +172,9 @@ importers:
         version: 5.8.3
 
 packages:
+
+  '@adobe/css-tools@4.4.2':
+    resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
 
   '@algolia/autocomplete-core@1.17.9':
     resolution: {integrity: sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==}
@@ -196,6 +266,9 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@asamuzakjp/css-color@3.1.7':
+    resolution: {integrity: sha512-Ok5fYhtwdyJQmU1PpEv6Si7Y+A4cYb8yNM9oiIJC9TzXPMuN9fvdonKJqcnz9TbFqV6bQ8z0giRq0iaOpGZV2g==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -706,6 +779,34 @@ packages:
     resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
     engines: {node: '>=6.9.0'}
 
+  '@csstools/color-helpers@5.0.2':
+    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.3':
+    resolution: {integrity: sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-color-parser@3.0.9':
+    resolution: {integrity: sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4':
+    resolution: {integrity: sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.3
+
+  '@csstools/css-tokenizer@3.0.3':
+    resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
+    engines: {node: '>=18'}
+
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
 
@@ -1159,13 +1260,50 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/compat@1.2.9':
+    resolution: {integrity: sha512-gCdSY54n7k+driCadyMNv8JSPzYLeDVM/ikZRtvtROBpRdFSkS8W9A82MqsaY7lZuwL0wiapgD0NT1xT0hyJsA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.10.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/config-array@0.20.0':
+    resolution: {integrity: sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.2.2':
+    resolution: {integrity: sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.13.0':
+    resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@9.26.0':
+    resolution: {integrity: sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.2.8':
+    resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.0':
     resolution: {integrity: sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==}
@@ -1175,6 +1313,14 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.6':
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -1188,6 +1334,14 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@humanwhocodes/retry@0.3.1':
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
+    engines: {node: '>=18.18'}
+
+  '@humanwhocodes/retry@0.4.2':
+    resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
+    engines: {node: '>=18.18'}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -1223,6 +1377,10 @@ packages:
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
+
+  '@modelcontextprotocol/sdk@1.11.0':
+    resolution: {integrity: sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==}
+    engines: {node: '>=18'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1427,6 +1585,11 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
+  '@sveltejs/adapter-auto@6.0.0':
+    resolution: {integrity: sha512-7mR2/G7vlXakaOj6QBSG9dwBfTgWjV+UnEMB5Z6Xu0ZbdXda6c0su1fNkg0ab0zlilSkloMA2NjCna02/DR7sA==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
   '@sveltejs/adapter-static@3.0.8':
     resolution: {integrity: sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==}
     peerDependencies:
@@ -1456,12 +1619,27 @@ packages:
       svelte: ^5.0.0-next.96 || ^5.0.0
       vite: ^5.0.0
 
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
   '@sveltejs/vite-plugin-svelte@4.0.4':
     resolution: {integrity: sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
       svelte: ^5.0.0-next.96 || ^5.0.0
       vite: ^5.0.0
+
+  '@sveltejs/vite-plugin-svelte@5.0.3':
+    resolution: {integrity: sha512-MCFS6CrQDu1yGwspm4qtli0e63vaPCehf6V7pIMP15AsWgMKrqDGCPFF/0kn4SP0ii4aySu4Pa62+fIRGFMjgw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.0.0
 
   '@sveltepress/theme-default@6.0.2':
     resolution: {integrity: sha512-tzoFQU7mX+dVA0YuAGrCb8rf0UKg/V3kqRDlDEMxxTZt4wc5OQr1VL7bx5iNIjRJRPyAgdqCPJJot1YfBbP6ag==}
@@ -1484,6 +1662,30 @@ packages:
       '@sveltejs/vite-plugin-svelte': ^4.0.1
       svelte: ^5.0.0
       vite: ^4.3.9 || ^5.0.0
+
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/svelte@5.2.7':
+    resolution: {integrity: sha512-aGhUaFmEXEVost4QOsbHUUbHLwi7ZZRRxAHFDO2Cmr0BZD3/3+XvaYEPq70Rdw0NRNjdqZHdARBEcrCOkPuAqw==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai-subset@1.3.6':
     resolution: {integrity: sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==}
@@ -1552,6 +1754,14 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/eslint-plugin@8.32.0':
+    resolution: {integrity: sha512-/jU9ettcntkBFmWUzzGgsClEi2ZFiikMX5eEQsmxIAWMOn4H3D4rvHssstmAHGVvrYnaMqdWWWg0b5M6IN/MTQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/parser@5.62.0':
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1562,9 +1772,20 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.32.0':
+    resolution: {integrity: sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/scope-manager@5.62.0':
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript-eslint/scope-manager@8.32.0':
+    resolution: {integrity: sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/type-utils@5.62.0':
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -1576,9 +1797,20 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/type-utils@8.32.0':
+    resolution: {integrity: sha512-t2vouuYQKEKSLtJaa5bB4jHeha2HJczQ6E5IXPDPgIty9EqcJxpr1QHQ86YyIPwDwxvUmLfP2YADQ5ZY4qddZg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript-eslint/types@8.32.0':
+    resolution: {integrity: sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@5.62.0':
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -1589,15 +1821,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.32.0':
+    resolution: {integrity: sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/utils@5.62.0':
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@typescript-eslint/utils@8.32.0':
+    resolution: {integrity: sha512-8S9hXau6nQ/sYVtC3D6ISIDoJzS1NsCK+gluVhLN2YkBPX+/1wkwyUiDKnxRh15579WoOIyVWnoyIf3yGI9REw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript-eslint/visitor-keys@8.32.0':
+    resolution: {integrity: sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.1':
     resolution: {integrity: sha512-JwoxboBh7Oz1v38tPbkrZ62ZXNHAk9bJ7c9x0eI5zBfBnBYGhURdbnh7Z4smN/MV48Y5OCcZb58n972UtbazsA==}
@@ -1710,17 +1959,50 @@ packages:
   '@vitest/expect@0.32.4':
     resolution: {integrity: sha512-m7EPUqmGIwIeoU763N+ivkFjTzbaBn0n9evsTOcde03ugy2avPs3kZbYmw3DkcH1j5mxhMhdamJkLQ6dM1bk/A==}
 
+  '@vitest/expect@3.1.3':
+    resolution: {integrity: sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==}
+
+  '@vitest/mocker@3.1.3':
+    resolution: {integrity: sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.1.3':
+    resolution: {integrity: sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==}
+
   '@vitest/runner@0.32.4':
     resolution: {integrity: sha512-cHOVCkiRazobgdKLnczmz2oaKK9GJOw6ZyRcaPdssO1ej+wzHVIkWiCiNacb3TTYPdzMddYkCgMjZ4r8C0JFCw==}
+
+  '@vitest/runner@3.1.3':
+    resolution: {integrity: sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==}
 
   '@vitest/snapshot@0.32.4':
     resolution: {integrity: sha512-IRpyqn9t14uqsFlVI2d7DFMImGMs1Q9218of40bdQQgMePwVdmix33yMNnebXcTzDU5eiV3eUsoxxH5v0x/IQA==}
 
+  '@vitest/snapshot@3.1.3':
+    resolution: {integrity: sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==}
+
   '@vitest/spy@0.32.4':
     resolution: {integrity: sha512-oA7rCOqVOOpE6rEoXuCOADX7Lla1LIa4hljI2MSccbpec54q+oifhziZIJXxlE/CvI2E+ElhBHzVu0VEvJGQKQ==}
 
+  '@vitest/spy@3.1.3':
+    resolution: {integrity: sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==}
+
   '@vitest/utils@0.32.4':
     resolution: {integrity: sha512-Gwnl8dhd1uJ+HXrYyV0eRqfmk9ek1ASE/LWfTCuWMw+d07ogHqp4hEAV28NiecimK6UY9DpSEPh+pXBA5gtTBg==}
+
+  '@vitest/utils@3.1.3':
+    resolution: {integrity: sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1735,6 +2017,10 @@ packages:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@7.1.3:
+    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+    engines: {node: '>= 14'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1765,6 +2051,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -1783,6 +2072,10 @@ packages:
 
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1828,6 +2121,10 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -1860,6 +2157,10 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1890,6 +2191,14 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1912,6 +2221,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1958,15 +2271,35 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-js-compat@3.42.0:
     resolution: {integrity: sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1980,10 +2313,21 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@4.3.1:
+    resolution: {integrity: sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==}
+    engines: {node: '>=18'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2006,6 +2350,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
+
   decode-named-character-reference@1.1.0:
     resolution: {integrity: sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==}
 
@@ -2014,6 +2361,10 @@ packages:
 
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
   deep-is@0.1.4:
@@ -2046,6 +2397,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2075,12 +2430,21 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -2099,6 +2463,14 @@ packages:
   emoticon@4.1.0:
     resolution: {integrity: sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  entities@6.0.0:
+    resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
+    engines: {node: '>=0.12'}
+
   error-stack-parser-es@0.1.5:
     resolution: {integrity: sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==}
 
@@ -2113,6 +2485,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2148,6 +2523,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -2161,6 +2539,12 @@ packages:
     engines: {node: '>=12'}
     peerDependencies:
       eslint: '>=6.0.0'
+
+  eslint-config-prettier@10.1.2:
+    resolution: {integrity: sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
 
   eslint-config-prettier@8.10.0:
     resolution: {integrity: sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==}
@@ -2178,6 +2562,16 @@ packages:
       svelte:
         optional: true
 
+  eslint-plugin-svelte@3.5.1:
+    resolution: {integrity: sha512-Qn1slddZHfqYiDO6IN8/iN3YL+VuHlgYjm30FT+hh0Jf/TX0jeZMTJXQMajFm5f6f6hURi+XO8P+NPYD+T4jkg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.1 || ^9.0.0
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -2186,9 +2580,17 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-scope@8.3.0:
+    resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -2196,8 +2598,22 @@ packages:
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
+  eslint@9.26.0:
+    resolution: {integrity: sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  espree@10.3.0:
+    resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -2228,9 +2644,38 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.1:
+    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.6:
+    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@7.5.0:
+    resolution: {integrity: sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: ^4.11 || 5 || ^5.0.0-beta.1
+
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.5:
     resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
@@ -2272,12 +2717,20 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
+    engines: {node: '>= 0.8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2286,6 +2739,10 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -2297,6 +2754,14 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@11.3.0:
     resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
@@ -2374,8 +2839,16 @@ packages:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
 
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
+  globals@16.0.0:
+    resolution: {integrity: sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -2433,8 +2906,28 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -2461,6 +2954,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -2471,6 +2968,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2573,6 +3074,12 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -2649,6 +3156,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -2749,6 +3265,9 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -2757,6 +3276,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -2815,6 +3338,14 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2914,6 +3445,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
+    engines: {node: '>= 0.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2924,6 +3463,10 @@ packages:
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -2957,6 +3500,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
@@ -2987,6 +3534,13 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     hasBin: true
 
+  nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3001,6 +3555,10 @@ packages:
 
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3042,6 +3600,13 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
@@ -3060,6 +3625,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -3072,6 +3641,10 @@ packages:
 
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -3086,6 +3659,10 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -3115,6 +3692,12 @@ packages:
     peerDependencies:
       postcss: ^8.3.3
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
   postcss-scss@4.0.9:
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
     engines: {node: '>=12.0'}
@@ -3123,6 +3706,10 @@ packages:
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-selector-parser@7.1.0:
+    resolution: {integrity: sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==}
     engines: {node: '>=4'}
 
   postcss@8.5.3:
@@ -3142,9 +3729,20 @@ packages:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
 
+  prettier-plugin-svelte@3.3.3:
+    resolution: {integrity: sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-bytes@5.6.0:
@@ -3155,12 +3753,20 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
 
   publint@0.1.16:
     resolution: {integrity: sha512-wJgk7HnXDT5Ap0DjFYbGz78kPkN44iQvDiaq8P63IEEyNU9mYXvaMd2cAyIM6OgqXM/IA3CK6XWIsRq+wjNpgw==}
@@ -3171,6 +3777,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
@@ -3179,6 +3789,17 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
+    engines: {node: '>= 0.8'}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3190,6 +3811,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3299,6 +3924,13 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -3325,8 +3957,15 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sander@0.5.1:
     resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
@@ -3340,8 +3979,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -3357,6 +4004,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3436,6 +4086,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
@@ -3495,9 +4149,26 @@ packages:
     peerDependencies:
       svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
 
+  svelte-check@4.1.7:
+    resolution: {integrity: sha512-1jX4BzXrQJhC/Jt3SqYf6Ntu//vmfc6VWp07JkRfK2nn+22yIblspVUo96gzMkg0Zov8lQicxhxsMzOctwcMQQ==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=5.0.0'
+
   svelte-eslint-parser@0.43.0:
     resolution: {integrity: sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  svelte-eslint-parser@1.1.3:
+    resolution: {integrity: sha512-DUc/z/vk+AFVoxGv54+BOBFqUrmUgNg2gSO2YqrE3OL6ro19/0azPmQj/4wN3s9RxuF5l7G0162q/Ddk4LJhZA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
@@ -3551,6 +4222,9 @@ packages:
     resolution: {integrity: sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -3581,26 +4255,63 @@ packages:
     resolution: {integrity: sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==}
     engines: {node: '>=14.0.0'}
 
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -3677,6 +4388,10 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -3692,6 +4407,13 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.32.0:
+    resolution: {integrity: sha512-UMq2kxdXCzinFFPsXc9o2ozIpYCCOiEC46MG3yEh5Vipq6BO27otTtEBZA1fQ66DulEUgE97ucQ/3YY66CPg0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -3773,6 +4495,10 @@ packages:
       vite:
         optional: true
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -3789,6 +4515,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
   vfile-message@4.0.2:
     resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
 
@@ -3798,6 +4528,11 @@ packages:
   vite-node@0.32.4:
     resolution: {integrity: sha512-L2gIw+dCxO0LK14QnUMoqSYpa9XRGnTTTDjW2h19Mr+GR0EFj4vx52W41gFXfMLqpA00eK4ZjOVYo1Xk//LFEw==}
     engines: {node: '>=v14.18.0'}
+    hasBin: true
+
+  vite-node@3.1.3:
+    resolution: {integrity: sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite-plugin-inspect@0.8.9:
@@ -3881,6 +4616,46 @@ packages:
       terser:
         optional: true
 
+  vite@6.3.5:
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.0.6:
     resolution: {integrity: sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==}
     peerDependencies:
@@ -3920,8 +4695,56 @@ packages:
       webdriverio:
         optional: true
 
+  vitest@3.1.3:
+    resolution: {integrity: sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.3
+      '@vitest/ui': 3.1.3
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -4008,6 +4831,25 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.2:
+    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -4031,10 +4873,20 @@ packages:
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
 
+  zod-to-json-schema@3.24.5:
+    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+    peerDependencies:
+      zod: ^3.24.1
+
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.2': {}
 
   '@algolia/autocomplete-core@1.17.9(@algolia/client-search@5.24.0)(algoliasearch@5.24.0)(search-insights@2.17.3)':
     dependencies:
@@ -4161,6 +5013,14 @@ snapshots:
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+
+  '@asamuzakjp/css-color@3.1.7':
+    dependencies:
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -4830,6 +5690,26 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@csstools/color-helpers@5.0.2': {}
+
+  '@csstools/css-calc@2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-color-parser@3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.3
+
+  '@csstools/css-tokenizer@3.0.3': {}
+
   '@docsearch/css@3.9.0': {}
 
   '@docsearch/js@3.9.0(@algolia/client-search@5.24.0)(search-insights@2.17.3)':
@@ -5069,7 +5949,30 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.26.0(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.26.0(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/compat@1.2.9(eslint@9.26.0(jiti@1.21.7))':
+    optionalDependencies:
+      eslint: 9.26.0(jiti@1.21.7)
+
+  '@eslint/config-array@0.20.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.0
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.2.2': {}
+
+  '@eslint/core@0.13.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -5085,7 +5988,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0
+      espree: 10.3.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.57.1': {}
+
+  '@eslint/js@9.26.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.2.8':
+    dependencies:
+      '@eslint/core': 0.13.0
+      levn: 0.4.1
 
   '@floating-ui/core@1.7.0':
     dependencies:
@@ -5098,6 +6024,13 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.6':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -5109,6 +6042,10 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@humanwhocodes/retry@0.3.1': {}
+
+  '@humanwhocodes/retry@0.4.2': {}
 
   '@iconify/types@2.0.0': {}
 
@@ -5152,6 +6089,21 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   '@lukeed/csprng@1.1.0': {}
+
+  '@modelcontextprotocol/sdk@1.11.0':
+    dependencies:
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.6
+      express: 5.1.0
+      express-rate-limit: 7.5.0(express@5.1.0)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.0
+      zod: 3.24.4
+      zod-to-json-schema: 3.24.5(zod@3.24.4)
+    transitivePeerDependencies:
+      - supports-color
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5334,6 +6286,11 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
+  '@sveltejs/adapter-auto@6.0.0(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))':
+    dependencies:
+      '@sveltejs/kit': 2.20.8(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      import-meta-resolve: 4.1.0
+
   '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))':
     dependencies:
       '@sveltejs/kit': 2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
@@ -5355,6 +6312,23 @@ snapshots:
       svelte: 5.28.2
       vite: 5.4.19(@types/node@20.17.32)(terser@5.39.0)
 
+  '@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      devalue: 5.1.1
+      esm-env: 1.2.2
+      import-meta-resolve: 4.1.0
+      kleur: 4.1.5
+      magic-string: 0.30.17
+      mrmime: 2.0.1
+      sade: 1.8.1
+      set-cookie-parser: 2.7.1
+      sirv: 3.0.1
+      svelte: 5.28.2
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
   '@sveltejs/package@2.3.11(svelte@5.28.2)(typescript@5.8.3)':
     dependencies:
       chokidar: 4.0.3
@@ -5375,6 +6349,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      debug: 4.4.0
+      svelte: 5.28.2
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
@@ -5385,6 +6368,19 @@ snapshots:
       svelte: 5.28.2
       vite: 5.4.19(@types/node@20.17.32)(terser@5.39.0)
       vitefu: 1.0.6(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      debug: 4.4.0
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.17
+      svelte: 5.28.2
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -5471,6 +6467,37 @@ snapshots:
       - rollup
       - supports-color
 
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.27.1
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.2
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
+  '@testing-library/svelte@5.2.7(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      svelte: 5.28.2
+    optionalDependencies:
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/chai-subset@1.3.6(@types/chai@4.3.20)':
     dependencies:
       '@types/chai': 4.3.20
@@ -5536,6 +6563,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.32.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.32.0
+      '@typescript-eslint/type-utils': 8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.32.0
+      eslint: 9.26.0(jiti@1.21.7)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
@@ -5548,10 +6592,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.32.0
+      '@typescript-eslint/types': 8.32.0
+      '@typescript-eslint/typescript-estree': 8.32.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.32.0
+      debug: 4.4.0
+      eslint: 9.26.0(jiti@1.21.7)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
+
+  '@typescript-eslint/scope-manager@8.32.0':
+    dependencies:
+      '@typescript-eslint/types': 8.32.0
+      '@typescript-eslint/visitor-keys': 8.32.0
 
   '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
@@ -5565,7 +6626,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.32.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      debug: 4.4.0
+      eslint: 9.26.0(jiti@1.21.7)
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@5.62.0': {}
+
+  '@typescript-eslint/types@8.32.0': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.8.3)':
     dependencies:
@@ -5577,6 +6651,20 @@ snapshots:
       semver: 7.7.1
       tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.32.0(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.32.0
+      '@typescript-eslint/visitor-keys': 8.32.0
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -5596,10 +6684,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.26.0(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.32.0
+      '@typescript-eslint/types': 8.32.0
+      '@typescript-eslint/typescript-estree': 8.32.0(typescript@5.8.3)
+      eslint: 9.26.0(jiti@1.21.7)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.32.0':
+    dependencies:
+      '@typescript-eslint/types': 8.32.0
+      eslint-visitor-keys: 4.2.0
 
   '@typescript/vfs@1.6.1(typescript@5.8.3)':
     dependencies:
@@ -5785,11 +6889,35 @@ snapshots:
       '@vitest/utils': 0.32.4
       chai: 4.5.0
 
+  '@vitest/expect@3.1.3':
+    dependencies:
+      '@vitest/spy': 3.1.3
+      '@vitest/utils': 3.1.3
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 3.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
+  '@vitest/pretty-format@3.1.3':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/runner@0.32.4':
     dependencies:
       '@vitest/utils': 0.32.4
       p-limit: 4.0.0
       pathe: 1.1.2
+
+  '@vitest/runner@3.1.3':
+    dependencies:
+      '@vitest/utils': 3.1.3
+      pathe: 2.0.3
 
   '@vitest/snapshot@0.32.4':
     dependencies:
@@ -5797,15 +6925,36 @@ snapshots:
       pathe: 1.1.2
       pretty-format: 29.7.0
 
+  '@vitest/snapshot@3.1.3':
+    dependencies:
+      '@vitest/pretty-format': 3.1.3
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
   '@vitest/spy@0.32.4':
     dependencies:
       tinyspy: 2.2.1
+
+  '@vitest/spy@3.1.3':
+    dependencies:
+      tinyspy: 3.0.2
 
   '@vitest/utils@0.32.4':
     dependencies:
       diff-sequences: 29.6.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vitest/utils@3.1.3':
+    dependencies:
+      '@vitest/pretty-format': 3.1.3
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
@@ -5816,6 +6965,8 @@ snapshots:
       acorn: 8.14.1
 
   acorn@8.14.1: {}
+
+  agent-base@7.1.3: {}
 
   ajv@6.12.6:
     dependencies:
@@ -5862,6 +7013,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -5882,6 +7037,8 @@ snapshots:
       is-array-buffer: 3.0.5
 
   assertion-error@1.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
 
@@ -5925,6 +7082,20 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.0
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.0
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -5957,6 +7128,8 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       load-tsconfig: 0.2.5
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -5993,6 +7166,19 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chai@5.2.0:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
+
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -6011,6 +7197,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -6052,13 +7240,28 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
 
   core-js-compat@3.42.0:
     dependencies:
       browserslist: 4.24.5
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6073,7 +7276,19 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@4.3.1:
+    dependencies:
+      '@asamuzakjp/css-color': 3.1.7
+      rrweb-cssom: 0.8.0
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -6097,6 +7312,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.5.0: {}
+
   decode-named-character-reference@1.1.0:
     dependencies:
       character-entities: 2.0.2
@@ -6106,6 +7323,8 @@ snapshots:
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -6134,6 +7353,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
@@ -6156,6 +7377,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6163,6 +7388,8 @@ snapshots:
       gopd: 1.2.0
 
   duplexer@0.1.2: {}
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -6175,6 +7402,10 @@ snapshots:
   emojilib@2.4.0: {}
 
   emoticon@4.1.0: {}
+
+  encodeurl@2.0.0: {}
+
+  entities@6.0.0: {}
 
   error-stack-parser-es@0.1.5: {}
 
@@ -6235,6 +7466,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6336,6 +7569,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -6344,6 +7579,10 @@ snapshots:
     dependencies:
       eslint: 8.57.1
       semver: 7.7.1
+
+  eslint-config-prettier@10.1.2(eslint@9.26.0(jiti@1.21.7)):
+    dependencies:
+      eslint: 9.26.0(jiti@1.21.7)
 
   eslint-config-prettier@8.10.0(eslint@8.57.1):
     dependencies:
@@ -6368,6 +7607,23 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
+  eslint-plugin-svelte@3.5.1(eslint@9.26.0(jiti@1.21.7))(svelte@5.28.2):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.26.0(jiti@1.21.7))
+      '@jridgewell/sourcemap-codec': 1.5.0
+      eslint: 9.26.0(jiti@1.21.7)
+      esutils: 2.0.3
+      known-css-properties: 0.35.0
+      postcss: 8.5.3
+      postcss-load-config: 3.1.4(postcss@8.5.3)
+      postcss-safe-parser: 7.0.1(postcss@8.5.3)
+      semver: 7.7.1
+      svelte-eslint-parser: 1.1.3(svelte@5.28.2)
+    optionalDependencies:
+      svelte: 5.28.2
+    transitivePeerDependencies:
+      - ts-node
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -6378,7 +7634,14 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@8.3.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.0: {}
 
   eslint@8.57.1:
     dependencies:
@@ -6423,7 +7686,57 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint@9.26.0(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.26.0(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.20.0
+      '@eslint/config-helpers': 0.2.2
+      '@eslint/core': 0.13.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.26.0
+      '@eslint/plugin-kit': 0.2.8
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.2
+      '@modelcontextprotocol/sdk': 1.11.0
+      '@types/estree': 1.0.7
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      zod: 3.24.4
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
   esm-env@1.2.2: {}
+
+  espree@10.3.0:
+    dependencies:
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
+      eslint-visitor-keys: 4.2.0
 
   espree@9.6.1:
     dependencies:
@@ -6451,7 +7764,57 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.7
+
   esutils@2.0.3: {}
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.1: {}
+
+  eventsource@3.0.6:
+    dependencies:
+      eventsource-parser: 3.0.1
+
+  expect-type@1.2.1: {}
+
+  express-rate-limit@7.5.0(express@5.1.0):
+    dependencies:
+      express: 5.1.0
+
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.5: {}
 
@@ -6489,6 +7852,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   filelist@1.0.4:
     dependencies:
       minimatch: 5.1.6
@@ -6496,6 +7863,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -6508,6 +7886,11 @@ snapshots:
       keyv: 4.5.4
       rimraf: 3.0.2
 
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
   flatted@3.3.3: {}
 
   for-each@0.3.5:
@@ -6515,6 +7898,10 @@ snapshots:
       is-callable: 1.2.7
 
   format@0.2.2: {}
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@11.3.0:
     dependencies:
@@ -6612,7 +7999,11 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
+  globals@14.0.0: {}
+
   globals@15.15.0: {}
+
+  globals@16.0.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -6678,7 +8069,37 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-void-elements@3.0.0: {}
+
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb@7.1.1: {}
 
@@ -6709,6 +8130,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -6721,6 +8144,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -6817,6 +8242,10 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.7
@@ -6888,6 +8317,33 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.3.1
+      data-urls: 5.0.0
+      decimal.js: 10.5.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.20
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.2
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.0.2: {}
 
@@ -6962,6 +8418,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  loupe@3.1.3: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -6971,6 +8429,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.25.9:
     dependencies:
@@ -7124,6 +8584,10 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.0.30: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -7340,6 +8804,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -7347,6 +8817,10 @@ snapshots:
       brace-expansion: 1.1.11
 
   minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
 
@@ -7374,6 +8848,8 @@ snapshots:
   natural-compare-lite@1.4.0: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   no-case@3.0.4:
     dependencies:
@@ -7406,6 +8882,10 @@ snapshots:
       npm-bundled: 2.0.1
       npm-normalize-package-bin: 2.0.0
 
+  nwsapi@2.2.20: {}
+
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -7424,6 +8904,10 @@ snapshots:
       destr: 2.0.5
       node-fetch-native: 1.6.6
       ufo: 1.6.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -7487,6 +8971,12 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.0
+
+  parseurl@1.3.3: {}
+
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
@@ -7500,6 +8990,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@8.2.0: {}
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
@@ -7508,6 +9000,8 @@ snapshots:
 
   pathval@1.1.1: {}
 
+  pathval@2.0.0: {}
+
   perfect-debounce@1.0.0: {}
 
   picocolors@1.1.1: {}
@@ -7515,6 +9009,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  pkce-challenge@5.0.0: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -7541,11 +9037,20 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
+  postcss-safe-parser@7.0.1(postcss@8.5.3):
+    dependencies:
+      postcss: 8.5.3
+
   postcss-scss@4.0.9(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
   postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-selector-parser@7.1.0:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -7565,11 +9070,24 @@ snapshots:
       prettier: 2.8.8
       svelte: 5.28.2
 
+  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.28.2):
+    dependencies:
+      prettier: 3.5.3
+      svelte: 5.28.2
+
   prettier@2.8.8: {}
+
+  prettier@3.5.3: {}
 
   pretty-bytes@5.6.0: {}
 
   pretty-bytes@6.1.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@29.7.0:
     dependencies:
@@ -7579,6 +9097,11 @@ snapshots:
 
   property-information@7.0.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   publint@0.1.16:
     dependencies:
       npm-packlist: 5.1.3
@@ -7586,6 +9109,10 @@ snapshots:
       sade: 1.8.1
 
   punycode@2.3.1: {}
+
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
 
   quansync@0.2.10: {}
 
@@ -7595,6 +9122,17 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      unpipe: 1.0.0
+
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
 
   readdirp@3.6.0:
@@ -7602,6 +9140,11 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -7779,6 +9322,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.40.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.0
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  rrweb-cssom@0.8.0: {}
+
   run-applescript@7.0.0: {}
 
   run-parallel@1.2.0:
@@ -7810,6 +9365,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   sander@0.5.1:
     dependencies:
       es6-promise: 3.3.1
@@ -7817,15 +9374,44 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   search-insights@2.17.3: {}
 
   semver@6.3.1: {}
 
   semver@7.7.1: {}
 
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.1: {}
 
@@ -7850,6 +9436,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -7943,6 +9531,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.1: {}
 
   std-env@3.9.0: {}
 
@@ -8038,6 +9628,18 @@ snapshots:
       - stylus
       - sugarss
 
+  svelte-check@4.1.7(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      chokidar: 4.0.3
+      fdir: 6.4.4(picomatch@4.0.2)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.28.2
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - picomatch
+
   svelte-eslint-parser@0.43.0(svelte@5.28.2):
     dependencies:
       eslint-scope: 7.2.2
@@ -8045,6 +9647,17 @@ snapshots:
       espree: 9.6.1
       postcss: 8.5.3
       postcss-scss: 4.0.9(postcss@8.5.3)
+    optionalDependencies:
+      svelte: 5.28.2
+
+  svelte-eslint-parser@1.1.3(svelte@5.28.2):
+    dependencies:
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      postcss: 8.5.3
+      postcss-scss: 4.0.9(postcss@8.5.3)
+      postcss-selector-parser: 7.1.0
     optionalDependencies:
       svelte: 5.28.2
 
@@ -8086,6 +9699,8 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
+  symbol-tree@3.2.4: {}
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -8115,21 +9730,47 @@ snapshots:
 
   tinypool@0.5.0: {}
 
+  tinypool@1.0.2: {}
+
+  tinyrainbow@2.0.0: {}
+
   tinyspy@2.2.1: {}
+
+  tinyspy@3.0.2: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-api-utils@2.1.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
 
   tslib@1.14.1: {}
 
@@ -8194,6 +9835,12 @@ snapshots:
 
   type-fest@0.20.2: {}
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -8226,6 +9873,16 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript-eslint@8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.32.0(@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.32.0(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)
+      eslint: 9.26.0(jiti@1.21.7)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.8.3: {}
 
@@ -8333,6 +9990,8 @@ snapshots:
       - rollup
       - supports-color
 
+  unpipe@1.0.0: {}
+
   upath@1.2.0: {}
 
   update-browserslist-db@1.1.3(browserslist@4.24.5):
@@ -8346,6 +10005,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.2:
     dependencies:
@@ -8374,6 +10035,27 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-node@3.1.3(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite-plugin-inspect@0.8.9(rollup@2.79.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)):
     dependencies:
@@ -8422,11 +10104,31 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.39.0
 
+  vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.25.3
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rollup: 4.40.1
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 20.17.32
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.39.0
+      tsx: 4.19.4
+      yaml: 2.7.1
+
   vitefu@1.0.6(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)):
     optionalDependencies:
       vite: 5.4.19(@types/node@20.17.32)(terser@5.39.0)
 
-  vitest@0.32.4(terser@5.39.0):
+  vitefu@1.0.6(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)):
+    optionalDependencies:
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
+  vitest@0.32.4(jsdom@26.1.0)(terser@5.39.0):
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-subset': 1.3.6(@types/chai@4.3.20)
@@ -8452,6 +10154,8 @@ snapshots:
       vite: 4.5.14(@types/node@20.17.32)(terser@5.39.0)
       vite-node: 0.32.4(@types/node@20.17.32)(terser@5.39.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -8461,7 +10165,65 @@ snapshots:
       - supports-color
       - terser
 
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1):
+    dependencies:
+      '@vitest/expect': 3.1.3
+      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.1.3
+      '@vitest/runner': 3.1.3
+      '@vitest/snapshot': 3.1.3
+      '@vitest/spy': 3.1.3
+      '@vitest/utils': 3.1.3
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      vite-node: 3.1.3(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.17.32
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@7.1.0:
     dependencies:
@@ -8636,6 +10398,12 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.18.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
   yallist@3.1.1: {}
 
   yaml@1.10.2: {}
@@ -8647,5 +10415,11 @@ snapshots:
   yocto-queue@1.2.1: {}
 
   zimmerframe@1.1.2: {}
+
+  zod-to-json-schema@3.24.5(zod@3.24.4):
+    dependencies:
+      zod: 3.24.4
+
+  zod@3.24.4: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^5.2.4
         version: 5.2.7(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@types/google.maps':
+        specifier: ^3.58.1
+        version: 3.58.1
       eslint:
         specifier: ^9.18.0
         version: 9.26.0(jiti@1.21.7)
@@ -143,8 +146,39 @@ importers:
         specifier: ^3.0.0
         version: 3.1.3(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
 
+  apps/storybook:
+    dependencies:
+      svelte-google-maps-api:
+        specifier: workspace:*
+        version: link:../../packages/svelte-google-maps-api
+    devDependencies:
+      '@storybook/svelte':
+        specifier: ^8.6.14
+        version: 8.6.18(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)
+      '@storybook/svelte-vite':
+        specifier: ^8.6.14
+        version: 8.6.18(@babel/core@7.27.1)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.3
+        version: 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      storybook:
+        specifier: ^8.6.14
+        version: 8.6.18(prettier@3.5.3)
+      svelte:
+        specifier: ^5.28.2
+        version: 5.28.2
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
   packages/svelte-google-maps-api:
     dependencies:
+      '@googlemaps/markerclusterer':
+        specifier: ^2.6.2
+        version: 2.6.2
       esm-env:
         specifier: ^1.0.0
         version: 1.2.2
@@ -1281,6 +1315,10 @@ packages:
     resolution: {integrity: sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/eslintrc@1.4.1':
+    resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1314,6 +1352,9 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@googlemaps/markerclusterer@2.6.2':
+    resolution: {integrity: sha512-U6uVhq8iWhiIckA89sgRu8OK35mjd6/3CuoZKWakKEf0QmRRWpatlsPb3kqXkoWSmbcZkopRiI4dnW6DQSd7bQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1327,9 +1368,18 @@ packages:
     engines: {node: '>=10.10.0'}
     deprecated: Use @eslint/config-array instead
 
+  '@humanwhocodes/config-array@0.9.5':
+    resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@1.2.1':
+    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
@@ -1577,6 +1627,67 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@storybook/builder-vite@8.6.18':
+    resolution: {integrity: sha512-XLqnOv4C36jlTd4uC8xpWBxv+7GV4/05zWJ0wAcU4qflorropUTirt4UQPGkwIzi+BVAhs9pJj+m4k0IWJtpHg==}
+    peerDependencies:
+      storybook: ^8.6.18
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@storybook/components@8.6.18':
+    resolution: {integrity: sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/core@8.6.18':
+    resolution: {integrity: sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==}
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
+  '@storybook/csf-plugin@8.6.18':
+    resolution: {integrity: sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/csf@0.1.12':
+    resolution: {integrity: sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==}
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/manager-api@8.6.18':
+    resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/preview-api@8.6.18':
+    resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/svelte-vite@8.6.18':
+    resolution: {integrity: sha512-iKhtHWtgZ7LCB0qn9Rjwngnn9dZWqFLAQfWnbrMvnpWF83xKyDp+baoifKiQm7nasf/XtC3wLpN/BKoEGTMEQQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      storybook: ^8.6.18
+      svelte: ^4.0.0 || ^5.0.0
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@storybook/svelte@8.6.18':
+    resolution: {integrity: sha512-r6Go7UwW+Go6BZSL+tVUjQDUBCZxR/85iJRgNvIXKJi3QLFNBGwHMh5TcptsTWt5qypw8QXTNUd3siHCQGcswg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      storybook: ^8.6.18
+      svelte: ^4.0.0 || ^5.0.0
+
+  '@storybook/theming@8.6.18':
+    resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
@@ -1707,6 +1818,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/google.maps@3.58.1':
     resolution: {integrity: sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==}
 
@@ -1733,6 +1847,9 @@ packages:
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2032,6 +2149,10 @@ packages:
     resolution: {integrity: sha512-CkaUygzZ91Xbw11s0CsHMawrK3tl+Ue57725HGRgRzKgt2Z4wvXVXRCtQfvzh8K7Tp4Zp7f1pyHAtMROtTJHxg==}
     engines: {node: '>= 14.0.0'}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2077,6 +2198,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -2117,6 +2242,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  better-opn@3.0.2:
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -2134,6 +2263,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browser-assert@1.2.1:
+    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
 
   browserslist@4.24.5:
     resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
@@ -2386,6 +2518,10 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
@@ -2436,6 +2572,23 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@1.4.1:
+    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@3.3.0:
+    resolution: {integrity: sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==}
+    engines: {node: '>= 4'}
+
+  domhandler@4.3.1:
+    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
+    engines: {node: '>= 4'}
+
+  domutils@2.8.0:
+    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2466,6 +2619,13 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+
+  entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
   entities@6.0.0:
     resolution: {integrity: sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==}
@@ -2503,6 +2663,11 @@ packages:
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2584,6 +2749,16 @@ packages:
     resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-utils@3.0.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+
+  eslint-visitor-keys@2.1.0:
+    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
+    engines: {node: '>=10'}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2591,6 +2766,12 @@ packages:
   eslint-visitor-keys@4.2.0:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@8.4.1:
+    resolution: {integrity: sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -2615,9 +2796,18 @@ packages:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  espree@9.2.0:
+    resolution: {integrity: sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
@@ -2685,6 +2875,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2786,6 +2980,9 @@ packages:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -2824,12 +3021,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -2913,6 +3110,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2-svelte@4.1.0:
+    resolution: {integrity: sha512-+4f4RBFz7Rj2Hp0ZbFbXC+Kzbd6S9PgjiuFtdT76VMNgKogrEZy0pG2UrPycPbrZzVEIM5lAT3lAdkSTCHLPjg==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -2935,6 +3135,10 @@ packages:
   ignore-walk@5.0.1:
     resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  ignore@4.0.6:
+    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
+    engines: {node: '>= 4'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2979,6 +3183,10 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -3017,6 +3225,11 @@ packages:
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -3127,6 +3340,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
@@ -3156,6 +3373,10 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@4.8.0:
+    resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
+    engines: {node: '>=12.0.0'}
 
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
@@ -3202,6 +3423,9 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3570,6 +3794,10 @@ packages:
     resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
     engines: {node: '>=18'}
 
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3761,6 +3989,14 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
 
@@ -3812,6 +4048,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3839,6 +4079,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  regexpp@3.2.0:
+    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
+    engines: {node: '>=8'}
 
   regexpu-core@6.2.0:
     resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
@@ -4075,6 +4319,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -4092,6 +4337,15 @@ packages:
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  storybook@8.6.18:
+    resolution: {integrity: sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -4134,6 +4388,9 @@ packages:
 
   strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4222,6 +4479,10 @@ packages:
     resolution: {integrity: sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==}
     engines: {node: '>=18'}
 
+  sveltedoc-parser@4.2.1:
+    resolution: {integrity: sha512-sWJRa4qOfRdSORSVw9GhfDEwsbsYsegnDzBevUCF6k/Eis/QqCu9lJ6I0+d/E2wOWCjOhlcJ3+jl/Iur+5mmCw==}
+    engines: {node: '>=10.0.0'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4240,6 +4501,9 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4312,6 +4576,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -4387,6 +4655,10 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -4499,6 +4771,10 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
+
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -4514,6 +4790,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  v8-compile-cache@2.4.0:
+    resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -4733,6 +5015,9 @@ packages:
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -5974,6 +6259,20 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/eslintrc@1.4.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
@@ -6024,6 +6323,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@googlemaps/markerclusterer@2.6.2':
+    dependencies:
+      '@types/supercluster': 7.1.3
+      fast-equals: 5.4.0
+      supercluster: 8.0.1
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -6039,7 +6344,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@humanwhocodes/config-array@0.9.5':
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.4.0
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@1.2.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
@@ -6274,6 +6589,104 @@ snapshots:
   '@sinclair/typebox@0.27.8': {}
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      browser-assert: 1.2.1
+      storybook: 8.6.18(prettier@3.5.3)
+      ts-dedent: 2.2.0
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+
+  '@storybook/components@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+
+  '@storybook/core@8.6.18(prettier@3.5.3)(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      better-opn: 3.0.2
+      browser-assert: 1.2.1
+      esbuild: 0.25.3
+      esbuild-register: 3.6.0(esbuild@0.25.3)
+      jsdoc-type-pratt-parser: 4.8.0
+      process: 0.11.10
+      recast: 0.23.11
+      semver: 7.7.1
+      util: 0.12.5
+      ws: 8.18.2
+    optionalDependencies:
+      prettier: 3.5.3
+    transitivePeerDependencies:
+      - bufferutil
+      - storybook
+      - supports-color
+      - utf-8-validate
+
+  '@storybook/csf-plugin@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+      unplugin: 1.16.1
+
+  '@storybook/csf@0.1.12':
+    dependencies:
+      type-fest: 2.19.0
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/manager-api@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+
+  '@storybook/preview-api@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+
+  '@storybook/svelte-vite@8.6.18(@babel/core@7.27.1)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      '@storybook/svelte': 8.6.18(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
+      magic-string: 0.30.17
+      storybook: 8.6.18(prettier@3.5.3)
+      svelte: 5.28.2
+      svelte-preprocess: 5.1.4(@babel/core@7.27.1)(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(svelte@5.28.2)(typescript@5.8.3)
+      svelte2tsx: 0.7.37(svelte@5.28.2)(typescript@5.8.3)
+      sveltedoc-parser: 4.2.1
+      ts-dedent: 2.2.0
+      typescript: 5.8.3
+      vite: 6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+
+  '@storybook/svelte@8.6.18(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)':
+    dependencies:
+      '@storybook/components': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/csf': 0.1.12
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/preview-api': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      storybook: 8.6.18(prettier@3.5.3)
+      svelte: 5.28.2
+      sveltedoc-parser: 4.2.1
+      ts-dedent: 2.2.0
+      type-fest: 2.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@storybook/theming@8.6.18(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -6514,6 +6927,8 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/google.maps@3.58.1': {}
 
   '@types/hast@3.0.4':
@@ -6537,6 +6952,10 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@types/semver@7.7.0': {}
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/trusted-types@2.0.7': {}
 
@@ -6998,6 +7417,8 @@ snapshots:
       '@algolia/requester-fetch': 5.24.0
       '@algolia/requester-node-http': 5.24.0
 
+  ansi-colors@4.1.3: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -7040,6 +7461,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   async-function@1.0.0: {}
 
   async@3.2.6: {}
@@ -7080,6 +7505,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
+
   binary-extensions@2.3.0: {}
 
   body-parser@2.2.0:
@@ -7108,6 +7537,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-assert@1.2.1: {}
 
   browserslist@4.24.5:
     dependencies:
@@ -7343,6 +7774,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  define-lazy-prop@2.0.0: {}
+
   define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
@@ -7381,6 +7814,28 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@1.4.1:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      entities: 2.2.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@3.3.0:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domhandler@4.3.1:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@2.8.0:
+    dependencies:
+      dom-serializer: 1.4.1
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7404,6 +7859,13 @@ snapshots:
   emoticon@4.1.0: {}
 
   encodeurl@2.0.0: {}
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
+
+  entities@2.2.0: {}
 
   entities@6.0.0: {}
 
@@ -7487,6 +7949,13 @@ snapshots:
       is-symbol: 1.1.1
 
   es6-promise@3.3.1: {}
+
+  esbuild-register@3.6.0(esbuild@0.25.3):
+    dependencies:
+      debug: 4.4.0
+      esbuild: 0.25.3
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -7639,9 +8108,59 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-utils@3.0.0(eslint@8.4.1):
+    dependencies:
+      eslint: 8.4.1
+      eslint-visitor-keys: 2.1.0
+
+  eslint-visitor-keys@2.1.0: {}
+
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.0: {}
+
+  eslint@8.4.1:
+    dependencies:
+      '@eslint/eslintrc': 1.4.1
+      '@humanwhocodes/config-array': 0.9.5
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0
+      doctrine: 3.0.0
+      enquirer: 2.4.1
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-utils: 3.0.0(eslint@8.4.1)
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      ignore: 4.0.6
+      import-fresh: 3.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      progress: 2.0.3
+      regexpp: 3.2.0
+      semver: 7.7.1
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+      v8-compile-cache: 2.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@8.57.1:
     dependencies:
@@ -7738,11 +8257,19 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 4.2.0
 
+  espree@9.2.0:
+    dependencies:
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
+      eslint-visitor-keys: 3.4.3
+
   espree@9.6.1:
     dependencies:
       acorn: 8.14.1
       acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 3.4.3
+
+  esprima@4.0.1: {}
 
   esquery@1.6.0:
     dependencies:
@@ -7821,6 +8348,8 @@ snapshots:
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -7931,6 +8460,8 @@ snapshots:
       functions-have-names: 1.2.3
       hasown: 2.0.2
       is-callable: 1.2.7
+
+  functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
 
@@ -8075,6 +8606,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2-svelte@4.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 3.3.0
+      domutils: 2.8.0
+      entities: 2.2.0
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -8106,6 +8644,8 @@ snapshots:
   ignore-walk@5.0.1:
     dependencies:
       minimatch: 5.1.6
+
+  ignore@4.0.6: {}
 
   ignore@5.3.2: {}
 
@@ -8154,6 +8694,11 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -8199,6 +8744,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
+
+  is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
 
@@ -8293,6 +8840,10 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
@@ -8317,6 +8868,8 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@4.8.0: {}
 
   jsdom@26.1.0:
     dependencies:
@@ -8368,6 +8921,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonpointer@5.0.1: {}
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -8926,6 +9481,12 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -9095,6 +9656,10 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process@0.11.10: {}
+
+  progress@2.0.3: {}
+
   property-information@7.0.0: {}
 
   proxy-addr@2.0.7:
@@ -9141,6 +9706,14 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -9182,6 +9755,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  regexpp@3.2.0: {}
 
   regexpu-core@6.2.0:
     dependencies:
@@ -9536,6 +10111,16 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  storybook@8.6.18(prettier@3.5.3):
+    dependencies:
+      '@storybook/core': 8.6.18(prettier@3.5.3)(storybook@8.6.18(prettier@3.5.3))
+    optionalDependencies:
+      prettier: 3.5.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -9601,6 +10186,10 @@ snapshots:
   strip-literal@1.3.0:
     dependencies:
       acorn: 8.14.1
+
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.1.0
 
   supports-color@7.2.0:
     dependencies:
@@ -9699,6 +10288,14 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
+  sveltedoc-parser@4.2.1:
+    dependencies:
+      eslint: 8.4.1
+      espree: 9.2.0
+      htmlparser2-svelte: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   symbol-tree@3.2.4: {}
 
   temp-dir@2.0.0: {}
@@ -9718,6 +10315,8 @@ snapshots:
       source-map-support: 0.5.21
 
   text-table@0.2.0: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -9771,6 +10370,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-dedent@2.2.0: {}
 
   tslib@1.14.1: {}
 
@@ -9834,6 +10435,8 @@ snapshots:
   type-fest@0.16.0: {}
 
   type-fest@0.20.2: {}
+
+  type-fest@2.19.0: {}
 
   type-is@2.0.1:
     dependencies:
@@ -9992,6 +10595,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.14.1
+      webpack-virtual-modules: 0.6.2
+
   upath@1.2.0: {}
 
   update-browserslist-db@1.1.3(browserslist@4.24.5):
@@ -10005,6 +10613,16 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.0
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.19
+
+  v8-compile-cache@2.4.0: {}
 
   vary@1.1.2: {}
 
@@ -10213,6 +10831,8 @@ snapshots:
   webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-encoding@3.1.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Publish the Storybook static build under the Docs Pages artifact at `/storybook/`.
- Trigger the Docs deployment when Storybook files change.
- Carry the component docs and Storybook updates forward to `main` so GitHub Pages can deploy them.

## Root cause
The Pages deployment workflow only runs for pushes to `main`. The latest docs work was merged into `add-drawing-manager-component`, so no Pages deployment ran. Also, the workflow only uploaded `apps/docs/build`, so Storybook was not included in the published artifact.

## Validation
- `corepack pnpm build --filter=docs`
- `HOME=/private/tmp/storybook-home STORYBOOK_DISABLE_TELEMETRY=1 corepack pnpm build --filter=storybook`