### PR TITLE
Fix Storybook build on clean CI

### DIFF
--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,6 +1,15 @@
 {
-	"extends": "../../tsconfig.json",
 	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"sourceMap": true,
 		"types": ["@types/google.maps", "node"]
 	},
 	"include": [".storybook/**/*", "src/**/*"]

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
-			"outputs": ["dist/**", ".svelte-kit/**", "build/**"]
+			"outputs": ["dist/**", ".svelte-kit/**", "build/**", "storybook-static/**"]
 		},
 		"lint": {},
 		"check": {},


### PR DESCRIPTION
## Summary
- Make the Storybook tsconfig independent from the root SvelteKit-generated config.
- Add Storybook's static output directory to Turbo build outputs.

## Root cause
Storybook was extending the root tsconfig, which depends on `.svelte-kit/tsconfig.json`. That generated file is not present in a clean CI checkout when Storybook builds, so Vite failed before compiling the preview.

## Validation
- `HOME=/private/tmp/storybook-home STORYBOOK_DISABLE_TELEMETRY=1 corepack pnpm build --filter=storybook --force`