### PR TITLE
Fix map component loading and stories

### DIFF
--- a/apps/docs/src/routes/components/advanced-marker/+page.md
+++ b/apps/docs/src/routes/components/advanced-marker/+page.md
@@ -10,61 +10,52 @@ The `AdvancedMarker` component creates and manages advanced markers on the map, 
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| position | google.maps.LatLng \| google.maps.LatLngLiteral | | Geographical coordinates for the marker |
-| options | google.maps.marker.AdvancedMarkerElementOptions | | Advanced marker configuration options |
-| onLoad | (marker: google.maps.marker.AdvancedMarkerElement) => void | | Callback when marker is loaded |
-| onUnmount | (marker: google.maps.marker.AdvancedMarkerElement) => void | | Callback before marker is destroyed |
+| Prop         | Type                                                       | Default | Description                             |
+| ------------ | ---------------------------------------------------------- | ------- | --------------------------------------- |
+| position     | google.maps.LatLng \| google.maps.LatLngLiteral            |         | Geographical coordinates for the marker |
+| title        | string                                                     |         | Rollover and accessibility text         |
+| zIndex       | number                                                     |         | Marker stacking order                   |
+| element      | HTMLElement                                                |         | Custom marker element                   |
+| gmpDraggable | boolean                                                    |         | Enables dragging                        |
+| options      | google.maps.marker.AdvancedMarkerElementOptions            |         | Advanced marker configuration options   |
+| onLoad       | (marker: google.maps.marker.AdvancedMarkerElement) => void |         | Callback when marker is loaded          |
+| onUnmount    | (marker: google.maps.marker.AdvancedMarkerElement) => void |         | Callback before marker is destroyed     |
 
 ### Event Handler Props
 
-| Prop | Type | Description |
-|------|------|-------------|
-| onClick | (e: google.maps.MapMouseEvent) => void | Click event handler |
-| onDblClick | (e: google.maps.MapMouseEvent) => void | Double click event handler |
-| onDrag | (e: google.maps.MapMouseEvent) => void | Drag event handler |
-| onDragEnd | (e: google.maps.MapMouseEvent) => void | Drag end event handler |
+| Prop        | Type                                   | Description              |
+| ----------- | -------------------------------------- | ------------------------ |
+| onClick     | (e: google.maps.MapMouseEvent) => void | Click event handler      |
+| onDrag      | (e: google.maps.MapMouseEvent) => void | Drag event handler       |
+| onDragEnd   | (e: google.maps.MapMouseEvent) => void | Drag end event handler   |
 | onDragStart | (e: google.maps.MapMouseEvent) => void | Drag start event handler |
-| onMouseDown | (e: google.maps.MapMouseEvent) => void | Mouse down event handler |
-| onMouseOut | (e: google.maps.MapMouseEvent) => void | Mouse out event handler |
-| onMouseOver | (e: google.maps.MapMouseEvent) => void | Mouse over event handler |
-| onMouseUp | (e: google.maps.MapMouseEvent) => void | Mouse up event handler |
-| onRightClick | (e: google.maps.MapMouseEvent) => void | Right click event handler |
 
 ## Usage
 
 ```svelte
 <script>
-  import { APIProvider, GoogleMap, AdvancedMarker } from 'svelte-google-maps-api';
-  
-  const apiKey = 'YOUR_API_KEY';
-  const mapOptions = {
-    center: { lat: 35.6812362, lng: 139.7649361 },
-    zoom: 12
-  };
-  
-  const position = { lat: 35.6812362, lng: 139.7649361 };
-  const markerOptions = {
-    title: 'Tokyo',
-    draggable: true
-  };
-  
-  function handleMarkerClick() {
-    alert('Advanced Marker clicked!');
-  }
+	import { APIProvider, GoogleMap, AdvancedMarker } from 'svelte-google-maps-api';
+
+	const apiKey = 'YOUR_API_KEY';
+	const mapOptions = {
+		center: { lat: 35.6812362, lng: 139.7649361 },
+		zoom: 12,
+		mapId: 'DEMO_MAP_ID'
+	};
+
+	const position = { lat: 35.6812362, lng: 139.7649361 };
+
+	function handleMarkerClick() {
+		alert('Advanced Marker clicked!');
+	}
 </script>
 
 <div style="height: 400px; width: 100%;">
-  <APIProvider {apiKey}>
-    <GoogleMap id="map" options={mapOptions} mapContainerStyle="width: 100%; height: 100%;">
-      <AdvancedMarker 
-        position={position} 
-        options={markerOptions}
-        onClick={handleMarkerClick}
-      />
-    </GoogleMap>
-  </APIProvider>
+	<APIProvider {apiKey} libraries={['marker']} mapIds={['DEMO_MAP_ID']}>
+		<GoogleMap id="map" options={mapOptions} mapContainerStyle="width: 100%; height: 100%;">
+			<AdvancedMarker {position} title="Tokyo" gmpDraggable onClick={handleMarkerClick} />
+		</GoogleMap>
+	</APIProvider>
 </div>
 ```
 
@@ -74,46 +65,37 @@ One of the main advantages of `AdvancedMarker` is the ability to use custom HTML
 
 ```svelte
 <script>
-  import { APIProvider, GoogleMap, AdvancedMarker } from 'svelte-google-maps-api';
-  
-  const apiKey = 'YOUR_API_KEY';
-  const mapOptions = {
-    center: { lat: 35.6812362, lng: 139.7649361 },
-    zoom: 12
-  };
-  
-  const position = { lat: 35.6812362, lng: 139.7649361 };
-  
-  // Create a custom element for the marker
-  let customElement;
-  
-  function createCustomElement() {
-    const element = document.createElement('div');
-    element.className = 'custom-marker';
-    element.innerHTML = `
-      <div style="background-color: #4285F4; color: white; padding: 8px 12px; border-radius: 4px; font-weight: bold;">
-        Tokyo
-      </div>
-    `;
-    return element;
-  }
-  
-  function handleLoad(marker) {
-    customElement = createCustomElement();
-    marker.content = customElement;
-  }
+	import { APIProvider, GoogleMap, AdvancedMarker } from 'svelte-google-maps-api';
+
+	const apiKey = 'YOUR_API_KEY';
+	const mapOptions = {
+		center: { lat: 35.6812362, lng: 139.7649361 },
+		zoom: 12,
+		mapId: 'DEMO_MAP_ID'
+	};
+
+	const position = { lat: 35.6812362, lng: 139.7649361 };
 </script>
 
 <div style="height: 400px; width: 100%;">
-  <APIProvider {apiKey}>
-    <GoogleMap id="map" options={mapOptions} mapContainerStyle="width: 100%; height: 100%;">
-      <AdvancedMarker 
-        position={position}
-        onLoad={handleLoad}
-      />
-    </GoogleMap>
-  </APIProvider>
+	<APIProvider {apiKey} libraries={['marker']} mapIds={['DEMO_MAP_ID']}>
+		<GoogleMap id="map" options={mapOptions} mapContainerStyle="width: 100%; height: 100%;">
+			<AdvancedMarker {position} title="Tokyo">
+				<div class="custom-marker">Tokyo</div>
+			</AdvancedMarker>
+		</GoogleMap>
+	</APIProvider>
 </div>
+
+<style>
+	.custom-marker {
+		background: #4285f4;
+		border-radius: 4px;
+		color: white;
+		font-weight: bold;
+		padding: 8px 12px;
+	}
+</style>
 ```
 
 ## Context
@@ -121,14 +103,14 @@ One of the main advantages of `AdvancedMarker` is the ability to use custom HTML
 The `AdvancedMarker` component consumes the context set by `GoogleMap` to access the map instance:
 
 ```javascript
-const { getMap } = getContext('map') ?? {};
-let map = getMap();
+const map = getContext('map');
 ```
 
 ## Notes
 
 - The `AdvancedMarker` component must be a child of the `GoogleMap` component.
 - It requires the Google Maps "marker" library to be loaded.
+- The map must use a `mapId`; `DEMO_MAP_ID` is suitable for local testing.
 - It allows for custom HTML content, making it more flexible than the standard `Marker` component.
 - Event listeners are automatically cleaned up when the component is destroyed.
 - The marker is automatically removed from the map when the component is unmounted.

--- a/apps/docs/src/routes/components/api-provider/+page.md
+++ b/apps/docs/src/routes/components/api-provider/+page.md
@@ -10,39 +10,39 @@ The `APIProvider` component is responsible for loading the Google Maps JavaScrip
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| apiKey | `string` | `''` | Google Maps API key. |
-| googleMapsApiKey | `string` | | React-compatible API key alias. |
-| googleMapsClientId | `string` | | Google Maps Premium Plan client id. Do not use with an API key. |
-| libraries | `Library[]` | `[]` | Google Maps libraries to load. |
-| version | `string` | `'weekly'` | Google Maps API version to load. |
-| language | `string` | | Language for the Google Maps API. |
-| region | `string` | | Region for the Google Maps API. |
-| channel | `string` | | Usage tracking channel. |
-| mapIds | `string[]` | | Map IDs for cloud-based map styling. |
-| authReferrerPolicy | `'origin'` | | Auth referrer policy. |
-| apiUrl | `string` | `'https://maps.googleapis.com'` | Google Maps API base URL. |
-| solutionChannel | `string` | | Google solution channel. |
-| id | `string` | `'svelte-google-maps-api-script'` | Script element id. |
-| nonce | `string` | | CSP nonce for the script tag. |
-| preventGoogleFontsLoading | `boolean` | `false` | Prevents Google Maps from injecting its default font styles. |
-| onLoad | `() => void` | | Called when the script has loaded. |
-| onError | `(error: Error) => void` | | Called when the script fails to load. |
-| onUnmount | `() => void` | | Called when the provider is destroyed. |
+| Prop                      | Type                     | Default                           | Description                                                     |
+| ------------------------- | ------------------------ | --------------------------------- | --------------------------------------------------------------- |
+| apiKey                    | `string`                 | `''`                              | Google Maps API key.                                            |
+| googleMapsApiKey          | `string`                 |                                   | API key alias.                                                  |
+| googleMapsClientId        | `string`                 |                                   | Google Maps Premium Plan client id. Do not use with an API key. |
+| libraries                 | `Library[]`              | `[]`                              | Google Maps libraries to load.                                  |
+| version                   | `string`                 | `'weekly'`                        | Google Maps API version to load.                                |
+| language                  | `string`                 |                                   | Language for the Google Maps API.                               |
+| region                    | `string`                 |                                   | Region for the Google Maps API.                                 |
+| channel                   | `string`                 |                                   | Usage tracking channel.                                         |
+| mapIds                    | `string[]`               |                                   | Map IDs for cloud-based map styling.                            |
+| authReferrerPolicy        | `'origin'`               |                                   | Auth referrer policy.                                           |
+| apiUrl                    | `string`                 | `'https://maps.googleapis.com'`   | Google Maps API base URL.                                       |
+| solutionChannel           | `string`                 |                                   | Google solution channel.                                        |
+| id                        | `string`                 | `'svelte-google-maps-api-script'` | Script element id.                                              |
+| nonce                     | `string`                 |                                   | CSP nonce for the script tag.                                   |
+| preventGoogleFontsLoading | `boolean`                | `false`                           | Prevents Google Maps from injecting its default font styles.    |
+| onLoad                    | `() => void`             |                                   | Called when the script has loaded.                              |
+| onError                   | `(error: Error) => void` |                                   | Called when the script fails to load.                           |
+| onUnmount                 | `() => void`             |                                   | Called when the provider is destroyed.                          |
 
 ## Usage
 
 ```svelte
 <script>
-  import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
-  
-  const apiKey = 'YOUR_API_KEY';
-  const libraries = ['places', 'geometry'];
+	import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
+
+	const apiKey = 'YOUR_API_KEY';
+	const libraries = ['places', 'geometry'];
 </script>
 
 <APIProvider {apiKey} {libraries}>
-  <GoogleMap id="map" options={{ center: { lat: 35.6812362, lng: 139.7649361 }, zoom: 10 }} />
+	<GoogleMap id="map" options={{ center: { lat: 35.6812362, lng: 139.7649361 }, zoom: 10 }} />
 </APIProvider>
 ```
 
@@ -52,18 +52,18 @@ The `APIProvider` component sets the `svelte-google-maps-api` context with the l
 
 ## Loading Multiple Libraries
 
-You can load additional Google Maps libraries by passing them in the `libraries` prop:
+You can load additional Google Maps libraries by passing them in the `libraries` prop. If the Google Maps script is already present, `APIProvider` imports the requested libraries before rendering child components:
 
 ```svelte
 <script>
-  import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
-  
-  const apiKey = 'YOUR_API_KEY';
-  const libraries = ['places', 'geometry', 'drawing', 'visualization'];
+	import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
+
+	const apiKey = 'YOUR_API_KEY';
+	const libraries = ['places', 'geometry', 'drawing', 'visualization'];
 </script>
 
 <APIProvider {apiKey} {libraries}>
-  <!-- Your map components here -->
+	<!-- Your map components here -->
 </APIProvider>
 ```
 
@@ -73,15 +73,15 @@ You can specify the language and region for the Google Maps API:
 
 ```svelte
 <script>
-  import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
-  
-  const apiKey = 'YOUR_API_KEY';
-  const language = 'ja';
-  const region = 'JP';
+	import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
+
+	const apiKey = 'YOUR_API_KEY';
+	const language = 'ja';
+	const region = 'JP';
 </script>
 
 <APIProvider {apiKey} {language} {region}>
-  <!-- Your map components here -->
+	<!-- Your map components here -->
 </APIProvider>
 ```
 
@@ -91,20 +91,20 @@ If you're using cloud-based map styling, you can specify map IDs:
 
 ```svelte
 <script>
-  import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
-  
-  const apiKey = 'YOUR_API_KEY';
-  const mapIds = ['YOUR_MAP_ID_1', 'YOUR_MAP_ID_2'];
-  
-  const mapOptions = {
-    center: { lat: 35.6812362, lng: 139.7649361 },
-    zoom: 10,
-    mapId: 'YOUR_MAP_ID_1'
-  };
+	import { APIProvider, GoogleMap } from 'svelte-google-maps-api';
+
+	const apiKey = 'YOUR_API_KEY';
+	const mapIds = ['YOUR_MAP_ID_1', 'YOUR_MAP_ID_2'];
+
+	const mapOptions = {
+		center: { lat: 35.6812362, lng: 139.7649361 },
+		zoom: 10,
+		mapId: 'YOUR_MAP_ID_1'
+	};
 </script>
 
 <APIProvider {apiKey} {mapIds}>
-  <GoogleMap id="map" options={mapOptions} />
+	<GoogleMap id="map" options={mapOptions} />
 </APIProvider>
 ```
 

--- a/apps/docs/src/routes/components/autocomplete/+page.md
+++ b/apps/docs/src/routes/components/autocomplete/+page.md
@@ -10,25 +10,25 @@ The `Autocomplete` component creates a Google Places autocomplete input.
 
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| options | `google.maps.places.AutocompleteOptions` | | Autocomplete options. |
-| value | `string` | `''` | Input value. |
-| placeholder | `string` | | Input placeholder. |
-| inputId | `string` | | Input id. |
-| inputClass | `string` | `''` | Input class. |
-| className | `string` | `''` | React-compatible class alias added to the input. |
-| inputStyle | `string` | `''` | Input inline style. |
-| disabled | `boolean` | `false` | Disables the input. |
-| bounds | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral` | | Result bias bounds. |
-| componentRestrictions | `google.maps.places.ComponentRestrictions` | | Component restrictions. |
-| restrictions | `google.maps.places.ComponentRestrictions` | | React-compatible alias for component restrictions. |
-| fields | `string[]` | | Place fields to return. |
-| strictBounds | `boolean` | | Restricts predictions to the bounds. |
-| types | `string[]` | | Place types. |
-| onPlaceChanged | `() => void` | | React-compatible place changed callback. |
-| onLoad | `(autocomplete: google.maps.places.Autocomplete) => void` | | Called after creation. |
-| onUnmount | `(autocomplete: google.maps.places.Autocomplete) => void` | | Called before teardown. |
+| Prop                  | Type                                                          | Default | Description                          |
+| --------------------- | ------------------------------------------------------------- | ------- | ------------------------------------ |
+| options               | `google.maps.places.AutocompleteOptions`                      |         | Autocomplete options.                |
+| value                 | `string`                                                      | `''`    | Input value.                         |
+| placeholder           | `string`                                                      |         | Input placeholder.                   |
+| inputId               | `string`                                                      |         | Input id.                            |
+| inputClass            | `string`                                                      | `''`    | Input class.                         |
+| className             | `string`                                                      | `''`    | Class alias added to the input.      |
+| inputStyle            | `string`                                                      | `''`    | Input inline style.                  |
+| disabled              | `boolean`                                                     | `false` | Disables the input.                  |
+| bounds                | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral` |         | Result bias bounds.                  |
+| componentRestrictions | `google.maps.places.ComponentRestrictions`                    |         | Component restrictions.              |
+| restrictions          | `google.maps.places.ComponentRestrictions`                    |         | Alias for component restrictions.    |
+| fields                | `string[]`                                                    |         | Place fields to return.              |
+| strictBounds          | `boolean`                                                     |         | Restricts predictions to the bounds. |
+| types                 | `string[]`                                                    |         | Place types.                         |
+| onPlaceChanged        | `() => void`                                                  |         | Place changed callback alias.        |
+| onLoad                | `(autocomplete: google.maps.places.Autocomplete) => void`     |         | Called after creation.               |
+| onUnmount             | `(autocomplete: google.maps.places.Autocomplete) => void`     |         | Called before teardown.              |
 
 ## Events
 
@@ -38,14 +38,14 @@ The component dispatches `place_changed` with the selected `google.maps.places.P
 
 ```svelte
 <APIProvider apiKey="YOUR_API_KEY" libraries={['places']}>
-  <Autocomplete
-    placeholder="Enter a location"
-    fields={['name', 'geometry.location']}
-    inputStyle="width: 300px; padding: 8px;"
-    on:place_changed={(event) => {
-      selectedPlace = event.detail;
-    }}
-  />
+	<Autocomplete
+		placeholder="Enter a location"
+		fields={['name', 'geometry.location']}
+		inputStyle="width: 300px; padding: 8px;"
+		on:place_changed={(event) => {
+			selectedPlace = event.detail;
+		}}
+	/>
 </APIProvider>
 ```
 

--- a/apps/docs/src/routes/components/bicycling-layer/+page.md
+++ b/apps/docs/src/routes/components/bicycling-layer/+page.md
@@ -11,32 +11,30 @@ The `BicyclingLayer` component displays bicycle paths, suggested routes, and oth
 
 ```svelte
 <script lang="ts">
-  import { APIProvider, GoogleMap, BicyclingLayer } from 'svelte-google-maps-api';
+	import { APIProvider, GoogleMap, BicyclingLayer } from 'svelte-google-maps-api';
 
-  let apiKey = 'YOUR_MAP_KEY'; // Replace with your API key
-  let map: google.maps.Map | null = null;
-  let mapCenter = { lat: 45.523, lng: -122.676 }; // Portland
-  let mapZoom = 14;
-
+	let apiKey = 'YOUR_MAP_KEY'; // Replace with your API key
+	let mapCenter = { lat: 45.523, lng: -122.676 }; // Portland
+	let mapZoom = 14;
 </script>
 
 <div style="height: 500px; width: 100%;">
-  <APIProvider {apiKey}>
-    <GoogleMap bind:map options={{ center: mapCenter, zoom: mapZoom }}>
-      <BicyclingLayer />
-    </GoogleMap>
-  </APIProvider>
+	<APIProvider {apiKey}>
+		<GoogleMap options={{ center: mapCenter, zoom: mapZoom }}>
+			<BicyclingLayer />
+		</GoogleMap>
+	</APIProvider>
 </div>
 ```
 
 ## Props
 
-This component does not typically take specific options via props in the standard API.
+| Prop      | Type                                          | Description                         |
+| --------- | --------------------------------------------- | ----------------------------------- |
+| onLoad    | `(layer: google.maps.BicyclingLayer) => void` | Called after the layer is created.  |
+| onUnmount | `(layer: google.maps.BicyclingLayer) => void` | Called before the layer is removed. |
 
 ## Notes
 
-*   The layer highlights:
-    *   Dark green: Dedicated bike trails.
-    *   Light green: Streets with dedicated bike lanes.
-    *   Dashed green: Streets recommended for cycling but without dedicated lanes.
-*   Availability and detail depend on the region and zoom level. 
+- The layer highlights dedicated bike trails, streets with bike lanes, and recommended cycling streets.
+- Availability and detail depend on the region and zoom level. Use a location with cycling coverage when verifying the layer.

--- a/apps/docs/src/routes/components/drawing-manager/+page.md
+++ b/apps/docs/src/routes/components/drawing-manager/+page.md
@@ -8,20 +8,22 @@ title: DrawingManager
 
 The `DrawingManager` component provides Google Maps drawing controls for markers, polylines, polygons, rectangles, and circles.
 
+The Google Maps Drawing Library is deprecated and is not available in the weekly channel (`v=3.65`). Use `version="3.64"` while that Maps JavaScript API version remains supported, or migrate drawing UI to a custom implementation.
+
 ## Props
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| drawingMode | `google.maps.drawing.OverlayType \| null` | `null` | Active drawing mode. |
-| drawingControl | `boolean` | `true` | Shows the drawing control UI. |
-| drawingControlOptions | `google.maps.drawing.DrawingControlOptions` | | Drawing control options. |
-| markerOptions | `google.maps.MarkerOptions` | | Options for drawn markers. |
-| circleOptions | `google.maps.CircleOptions` | | Options for drawn circles. |
-| polygonOptions | `google.maps.PolygonOptions` | | Options for drawn polygons. |
-| polylineOptions | `google.maps.PolylineOptions` | | Options for drawn polylines. |
-| rectangleOptions | `google.maps.RectangleOptions` | | Options for drawn rectangles. |
-| onLoad | `(manager: google.maps.drawing.DrawingManager) => void` | | Called after creation. |
-| onUnmount | `(manager: google.maps.drawing.DrawingManager) => void` | | Called before teardown. |
+| Prop                  | Type                                                    | Default | Description                   |
+| --------------------- | ------------------------------------------------------- | ------- | ----------------------------- |
+| drawingMode           | `google.maps.drawing.OverlayType \| null`               | `null`  | Active drawing mode.          |
+| drawingControl        | `boolean`                                               | `true`  | Shows the drawing control UI. |
+| drawingControlOptions | `google.maps.drawing.DrawingControlOptions`             |         | Drawing control options.      |
+| markerOptions         | `google.maps.MarkerOptions`                             |         | Options for drawn markers.    |
+| circleOptions         | `google.maps.CircleOptions`                             |         | Options for drawn circles.    |
+| polygonOptions        | `google.maps.PolygonOptions`                            |         | Options for drawn polygons.   |
+| polylineOptions       | `google.maps.PolylineOptions`                           |         | Options for drawn polylines.  |
+| rectangleOptions      | `google.maps.RectangleOptions`                          |         | Options for drawn rectangles. |
+| onLoad                | `(manager: google.maps.drawing.DrawingManager) => void` |         | Called after creation.        |
+| onUnmount             | `(manager: google.maps.drawing.DrawingManager) => void` |         | Called before teardown.       |
 
 ## Events
 
@@ -30,12 +32,12 @@ The `DrawingManager` component provides Google Maps drawing controls for markers
 ## Usage
 
 ```svelte
-<APIProvider apiKey="YOUR_API_KEY" libraries={['drawing']}>
-  <GoogleMap options={{ center, zoom: 12 }}>
-    <DrawingManager
-      drawingControl
-      onOverlayComplete={(event) => console.log(event.type, event.overlay)}
-    />
-  </GoogleMap>
+<APIProvider apiKey="YOUR_API_KEY" libraries={['drawing']} version="3.64">
+	<GoogleMap options={{ center, zoom: 12 }} mapContainerStyle="width: 100%; height: 400px;">
+		<DrawingManager
+			drawingControl
+			onOverlayComplete={(event) => console.log(event.type, event.overlay)}
+		/>
+	</GoogleMap>
 </APIProvider>
 ```

--- a/apps/docs/src/routes/components/marker-clusterer/+page.md
+++ b/apps/docs/src/routes/components/marker-clusterer/+page.md
@@ -2,7 +2,7 @@
 title: MarkerClusterer
 ---
 
-The `MarkerClusterer` component clusters child markers. It uses the modern `@googlemaps/markerclusterer` implementation while keeping a React-compatible `onClick(cluster)` convenience prop.
+The `MarkerClusterer` component clusters child markers. It uses the modern `@googlemaps/markerclusterer` implementation while keeping an `onClick(cluster)` convenience prop.
 
 ## Storybook
 
@@ -10,21 +10,21 @@ The `MarkerClusterer` component clusters child markers. It uses the modern `@goo
 
 ## Props
 
-| Prop | Type | Description |
-|------|------|-------------|
-| options | `Omit<MarkerClustererOptions, 'map' \| 'markers'>` | Marker clusterer options. |
-| markers | `Marker[]` | Optional marker instances to cluster. Child markers register automatically. |
-| onClick | `(cluster) => void` | Convenience cluster click handler. |
-| onClusterClick | `MarkerClustererOptions['onClusterClick']` | Native cluster click handler. |
-| onLoad | `(clusterer) => void` | Called after clusterer creation. |
-| onUnmount | `(clusterer) => void` | Called before clusterer removal. |
+| Prop           | Type                                               | Description                                                                 |
+| -------------- | -------------------------------------------------- | --------------------------------------------------------------------------- |
+| options        | `Omit<MarkerClustererOptions, 'map' \| 'markers'>` | Marker clusterer options.                                                   |
+| markers        | `Marker[]`                                         | Optional marker instances to cluster. Child markers register automatically. |
+| onClick        | `(cluster) => void`                                | Convenience cluster click handler.                                          |
+| onClusterClick | `MarkerClustererOptions['onClusterClick']`         | Native cluster click handler.                                               |
+| onLoad         | `(clusterer) => void`                              | Called after clusterer creation.                                            |
+| onUnmount      | `(clusterer) => void`                              | Called before clusterer removal.                                            |
 
 ## Usage
 
 ```svelte
 <MarkerClusterer onClick={(cluster) => console.log(cluster.count)}>
-  {#each locations as position}
-    <Marker {position} />
-  {/each}
+	{#each locations as position}
+		<Marker {position} />
+	{/each}
 </MarkerClusterer>
 ```

--- a/apps/storybook/src/stories/ComponentStory.svelte
+++ b/apps/storybook/src/stories/ComponentStory.svelte
@@ -37,7 +37,9 @@
 
 	const STORYBOOK_API_KEY_STORAGE_KEY = 'svelte-google-maps-api:storybook-google-maps-api-key';
 	const fallbackApiKey = import.meta.env.STORYBOOK_GOOGLE_MAPS_API_KEY ?? '';
+	const mapsApiVersion = '3.64';
 	const center = { lat: 35.6812362, lng: 139.7649361 };
+	const bicyclingCenter = { lat: 45.523, lng: -122.676 };
 	const second = { lat: 35.658584, lng: 139.7454316 };
 	const third = { lat: 35.710063, lng: 139.8107 };
 	const bounds = {
@@ -50,6 +52,11 @@
 	const mapOptions: google.maps.MapOptions = {
 		center,
 		zoom: 12,
+		mapId: 'DEMO_MAP_ID'
+	};
+	const bicyclingMapOptions: google.maps.MapOptions = {
+		center: bicyclingCenter,
+		zoom: 14,
 		mapId: 'DEMO_MAP_ID'
 	};
 	const heatmapData = [
@@ -88,8 +95,15 @@
 	let apiKeyMessage = '';
 	let isApiKeyReady = false;
 	let shouldRememberApiKey = false;
+	let advancedMarkerLoaded = false;
+	let bicyclingLayerLoaded = false;
+	let drawingManagerLoaded = false;
 
 	$: libraries = getLibraries(componentName);
+	$: storyMapOptions = componentName === 'BicyclingLayer' ? bicyclingMapOptions : mapOptions;
+	$: if (componentName !== 'AdvancedMarker') advancedMarkerLoaded = false;
+	$: if (componentName !== 'BicyclingLayer') bicyclingLayerLoaded = false;
+	$: if (componentName !== 'DrawingManager') drawingManagerLoaded = false;
 
 	onMount(() => {
 		let storedApiKey = '';
@@ -321,7 +335,7 @@
 
 {#if isApiKeyReady && apiKey && componentName === 'APIProvider'}
 	<div class="map-frame">
-		<APIProvider {apiKey}>
+		<APIProvider {apiKey} version={mapsApiVersion}>
 			<GoogleMap options={mapOptions} mapContainerStyle="width:100%;height:100%;">
 				<Marker position={center} options={{ title: 'APIProvider story marker' }} />
 			</GoogleMap>
@@ -329,19 +343,19 @@
 	</div>
 {:else if isApiKeyReady && apiKey && componentName === 'Autocomplete'}
 	<div class="panel-frame">
-		<APIProvider {apiKey} libraries={['places']}>
+		<APIProvider {apiKey} libraries={['places']} version={mapsApiVersion}>
 			<Autocomplete placeholder="Search for a place" inputStyle="width:320px;padding:10px;" />
 		</APIProvider>
 	</div>
 {:else if isApiKeyReady && apiKey && componentName === 'StandaloneSearchBox'}
 	<div class="panel-frame">
-		<APIProvider {apiKey} libraries={['places']}>
+		<APIProvider {apiKey} libraries={['places']} version={mapsApiVersion}>
 			<StandaloneSearchBox placeholder="Search places" inputStyle="width:320px;padding:10px;" />
 		</APIProvider>
 	</div>
 {:else if isApiKeyReady && apiKey && componentName === 'StreetViewPanorama'}
 	<div class="map-frame">
-		<APIProvider {apiKey}>
+		<APIProvider {apiKey} version={mapsApiVersion}>
 			<StreetViewPanorama
 				position={center}
 				pov={{ heading: 165, pitch: 0 }}
@@ -352,30 +366,39 @@
 	</div>
 {:else if isApiKeyReady && apiKey && componentName === 'StreetViewService'}
 	<div class="panel-frame">
-		<APIProvider {apiKey}>
+		<APIProvider {apiKey} version={mapsApiVersion}>
 			<StreetViewService onLoad={() => (serviceStatus = 'StreetViewService loaded')} />
 			<p>{serviceStatus}</p>
 		</APIProvider>
 	</div>
 {:else if isApiKeyReady && apiKey && componentName === 'DistanceMatrixService'}
 	<div class="panel-frame">
-		<APIProvider {apiKey}>
+		<APIProvider {apiKey} version={mapsApiVersion}>
 			<DistanceMatrixService options={distanceRequest} callback={handleDistanceMatrix} />
 			<p>{serviceStatus}</p>
 		</APIProvider>
 	</div>
 {:else if isApiKeyReady && apiKey}
 	<div class="map-frame">
-		<APIProvider {apiKey} {libraries} mapIds={['DEMO_MAP_ID']}>
-			<GoogleMap options={mapOptions} mapContainerStyle="width:100%;height:100%;">
+		<APIProvider {apiKey} {libraries} version={mapsApiVersion} mapIds={['DEMO_MAP_ID']}>
+			<GoogleMap options={storyMapOptions} mapContainerStyle="width:100%;height:100%;">
 				{#if componentName === 'GoogleMap'}
 					<Marker position={center} options={{ title: 'Tokyo Station' }} />
 				{:else if componentName === 'Marker'}
 					<Marker position={center} options={{ title: 'Marker', draggable: true }} />
 				{:else if componentName === 'AdvancedMarker'}
-					<AdvancedMarker position={center} title="Advanced marker">
+					<AdvancedMarker
+						position={center}
+						title="Advanced marker"
+						onLoad={() => (advancedMarkerLoaded = true)}
+					>
 						<div class="advanced-marker">A</div>
 					</AdvancedMarker>
+					{#if advancedMarkerLoaded}
+						<MapControl position={2 as google.maps.ControlPosition}>
+							<div class="control">Advanced marker loaded</div>
+						</MapControl>
+					{/if}
 				{:else if componentName === 'InfoWindow'}
 					<Marker position={center} />
 					<InfoWindow position={center}>
@@ -422,7 +445,12 @@
 				{:else if componentName === 'TransitLayer'}
 					<TransitLayer />
 				{:else if componentName === 'BicyclingLayer'}
-					<BicyclingLayer />
+					<BicyclingLayer onLoad={() => (bicyclingLayerLoaded = true)} />
+					{#if bicyclingLayerLoaded}
+						<MapControl position={2 as google.maps.ControlPosition}>
+							<div class="control">Bicycling layer loaded</div>
+						</MapControl>
+					{/if}
 				{:else if componentName === 'GroundOverlay'}
 					<GroundOverlay url={groundOverlayUrl} {bounds} opacity={0.55} />
 				{:else if componentName === 'OverlayView'}
@@ -434,7 +462,12 @@
 						<button class="control">Map control</button>
 					</MapControl>
 				{:else if componentName === 'DrawingManager'}
-					<DrawingManager drawingControl />
+					<DrawingManager drawingControl onLoad={() => (drawingManagerLoaded = true)} />
+					{#if drawingManagerLoaded}
+						<MapControl position={2 as google.maps.ControlPosition}>
+							<div class="control">Drawing manager loaded</div>
+						</MapControl>
+					{/if}
 				{:else if componentName === 'DirectionsRenderer'}
 					<DirectionsService options={directionsRequest} callback={handleDirectionsResult} />
 					{#if directions}

--- a/packages/svelte-google-maps-api/src/lib/APIProvider.svelte
+++ b/packages/svelte-google-maps-api/src/lib/APIProvider.svelte
@@ -43,19 +43,71 @@
 	const CALLBACK_NAME = '__svelteGoogleMapApiCallback__';
 
 	let scriptElement: HTMLScriptElement | null = null;
+	let loadRequestId = 0;
+	let loadedLibrariesSignature = '';
+	let isDestroyed = false;
 	type CallbackWindow = Window & Record<string, (() => void) | undefined>;
+
+	function getLibrariesSignature(librariesToLoad: Library[]) {
+		return [...new Set(librariesToLoad)].sort().join(',');
+	}
+
+	function normalizeError(loadError: unknown) {
+		return loadError instanceof Error ? loadError : new Error(String(loadError));
+	}
+
+	async function importRequestedLibraries(gmaps: typeof google.maps) {
+		const librariesToLoad = [...new Set(libraries)].sort();
+
+		if (librariesToLoad.length === 0) return;
+		if (typeof gmaps.importLibrary !== 'function') return;
+
+		await Promise.all(librariesToLoad.map((library) => gmaps.importLibrary(library)));
+	}
+
+	async function completeLoad(gmaps: typeof google.maps) {
+		const requestId = ++loadRequestId;
+		const requestedLibrariesSignature = getLibrariesSignature(libraries);
+
+		statusStore.set('loading');
+		error = null;
+
+		try {
+			await importRequestedLibraries(gmaps);
+		} catch (loadError) {
+			if (requestId !== loadRequestId || isDestroyed) return;
+
+			const nextError = normalizeError(loadError);
+			console.error('svelte-google-maps-api: Failed to load Google Maps libraries.', nextError);
+			statusStore.set('error');
+			error = nextError;
+			onError?.(nextError);
+			return;
+		}
+
+		if (requestId !== loadRequestId || isDestroyed) return;
+
+		googleMapsApi = gmaps;
+		loadedLibrariesSignature = requestedLibrariesSignature;
+		statusStore.set('loaded');
+		onLoad?.();
+	}
 
 	$: if (browser && !document.getElementById(id)) {
 		const resolvedApiKey = googleMapsApiKey ?? apiKey;
 
 		if (resolvedApiKey && googleMapsClientId) {
-			const apiKeyError = new Error('Specify either apiKey/googleMapsApiKey or googleMapsClientId, not both');
+			const apiKeyError = new Error(
+				'Specify either apiKey/googleMapsApiKey or googleMapsClientId, not both'
+			);
 			console.error(`svelte-google-maps-api: ${apiKeyError.message}`);
 			statusStore.set('error');
 			error = apiKeyError;
 			onError?.(apiKeyError);
 		} else if (!resolvedApiKey && !googleMapsClientId) {
-			console.error('svelte-google-maps-api: apiKey or googleMapsClientId is required for APIProvider');
+			console.error(
+				'svelte-google-maps-api: apiKey or googleMapsClientId is required for APIProvider'
+			);
 			statusStore.set('error');
 			error = new Error('apiKey or googleMapsClientId is required');
 			onError?.(error);
@@ -66,15 +118,13 @@
 			const callbackWindow = window as unknown as CallbackWindow;
 
 			callbackWindow[CALLBACK_NAME] = () => {
-				googleMapsApi = window.google.maps;
-				statusStore.set('loaded');
-				onLoad?.();
-
-				try {
-					delete callbackWindow[CALLBACK_NAME];
-				} catch (e) {
-					callbackWindow[CALLBACK_NAME] = undefined;
-				}
+				completeLoad(window.google.maps).finally(() => {
+					try {
+						delete callbackWindow[CALLBACK_NAME];
+					} catch (e) {
+						callbackWindow[CALLBACK_NAME] = undefined;
+					}
+				});
 			};
 
 			const script = document.createElement('script');
@@ -125,8 +175,11 @@
 			document.head.appendChild(scriptElement);
 		}
 	} else if (browser && document.getElementById(id) && window.google && window.google.maps) {
-		statusStore.set('loaded');
-		googleMapsApi = window.google.maps;
+		const requestedLibrariesSignature = getLibrariesSignature(libraries);
+
+		if (!googleMapsApi || requestedLibrariesSignature !== loadedLibrariesSignature) {
+			completeLoad(window.google.maps);
+		}
 	}
 
 	$: setContext<APIProviderContext>('svelte-google-maps-api', {
@@ -137,6 +190,9 @@
 
 	onDestroy(() => {
 		if (browser) {
+			isDestroyed = true;
+			loadRequestId += 1;
+
 			const callbackWindow = window as unknown as CallbackWindow;
 			if (typeof callbackWindow[CALLBACK_NAME] !== 'undefined') {
 				try {

--- a/packages/svelte-google-maps-api/src/lib/AdvancedMarker.svelte
+++ b/packages/svelte-google-maps-api/src/lib/AdvancedMarker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContext, onDestroy, onMount, tick } from 'svelte';
+	import { getContext, onDestroy, tick } from 'svelte';
 	import { BROWSER as browser } from 'esm-env';
 	import type { APIProviderContext } from './APIProvider.svelte';
 	import type { ClusterableMarker, MarkerClustererContext } from './types/markerClusterer.js';

--- a/packages/svelte-google-maps-api/src/lib/DrawingManager.svelte
+++ b/packages/svelte-google-maps-api/src/lib/DrawingManager.svelte
@@ -4,7 +4,8 @@
 	import type { APIProviderContext } from './APIProvider.svelte';
 
 	export let drawingMode: google.maps.drawing.OverlayType | null = null;
-	export let drawingControlOptions: google.maps.drawing.DrawingControlOptions | undefined = undefined;
+	export let drawingControlOptions: google.maps.drawing.DrawingControlOptions | undefined =
+		undefined;
 	export let circleOptions: google.maps.CircleOptions | undefined = undefined;
 	export let markerOptions: google.maps.MarkerOptions | undefined = undefined;
 	export let polygonOptions: google.maps.PolygonOptions | undefined = undefined;
@@ -14,13 +15,18 @@
 
 	export let onCircleComplete: ((circle: google.maps.Circle) => void) | undefined = undefined;
 	export let onMarkerComplete: ((marker: google.maps.Marker) => void) | undefined = undefined;
-	export let onOverlayComplete: ((event: google.maps.drawing.OverlayCompleteEvent) => void) | undefined = undefined;
+	export let onOverlayComplete:
+		| ((event: google.maps.drawing.OverlayCompleteEvent) => void)
+		| undefined = undefined;
 	export let onPolygonComplete: ((polygon: google.maps.Polygon) => void) | undefined = undefined;
 	export let onPolylineComplete: ((polyline: google.maps.Polyline) => void) | undefined = undefined;
-	export let onRectangleComplete: ((rectangle: google.maps.Rectangle) => void) | undefined = undefined;
+	export let onRectangleComplete: ((rectangle: google.maps.Rectangle) => void) | undefined =
+		undefined;
 	export let onDrawingModeChange: (() => void) | undefined = undefined;
-	export let onLoad: ((drawingManager: google.maps.drawing.DrawingManager) => void) | undefined = undefined;
-	export let onUnmount: ((drawingManager: google.maps.drawing.DrawingManager) => void) | undefined = undefined;
+	export let onLoad: ((drawingManager: google.maps.drawing.DrawingManager) => void) | undefined =
+		undefined;
+	export let onUnmount: ((drawingManager: google.maps.drawing.DrawingManager) => void) | undefined =
+		undefined;
 
 	let circleCompleteListener: google.maps.MapsEventListener | undefined = undefined;
 	let markerCompleteListener: google.maps.MapsEventListener | undefined = undefined;
@@ -35,18 +41,24 @@
 	const map = getContext<google.maps.Map>('map');
 
 	$: if ($status === 'loaded' && googleMapsApi && map && !drawingManager) {
-		drawingManager = new googleMapsApi.drawing.DrawingManager({
-			map: map,
-			drawingMode,
-			drawingControl,
-			drawingControlOptions,
-			circleOptions,
-			markerOptions,
-			polygonOptions,
-			polylineOptions,
-			rectangleOptions
-		});
-		onLoad?.(drawingManager);
+		if (!googleMapsApi.drawing?.DrawingManager) {
+			console.error(
+				'svelte-google-maps-api: DrawingManager requires the "drawing" library and a Maps JavaScript API version where the Drawing Library is still available.'
+			);
+		} else {
+			drawingManager = new googleMapsApi.drawing.DrawingManager({
+				map: map,
+				drawingMode,
+				drawingControl,
+				drawingControlOptions,
+				circleOptions,
+				markerOptions,
+				polygonOptions,
+				polylineOptions,
+				rectangleOptions
+			});
+			onLoad?.(drawingManager);
+		}
 	}
 
 	onDestroy(() => {

--- a/packages/svelte-google-maps-api/src/lib/GoogleMap.svelte
+++ b/packages/svelte-google-maps-api/src/lib/GoogleMap.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContext, onDestroy, onMount } from 'svelte';
+	import { getContext, onDestroy } from 'svelte';
 	import { BROWSER as browser } from 'esm-env';
 	import { setContext } from 'svelte';
 	import type { APIProviderContext } from './APIProvider.svelte';
@@ -108,7 +108,6 @@
 	}
 
 	$: if (map && onClick && googleMapsApi && browser) {
-		console.log('ddddd');
 		if (clickListener !== null) {
 			googleMapsApi.event.removeListener(clickListener);
 		}
@@ -127,6 +126,10 @@
 			googleMapsApi.event.removeListener(centerChangedListener);
 		}
 		centerChangedListener = googleMapsApi.event.addListener(map, 'center_changed', onCenterChanged);
+	}
+
+	$: if (map && options) {
+		map.setOptions(options);
 	}
 
 	const initialize = (gmaps: typeof google.maps) => {


### PR DESCRIPTION
## Summary
- Load requested Google Maps libraries with `importLibrary()` when the Maps script is already present.
- Guard `DrawingManager` when the drawing library is unavailable, and keep Storybook on a Maps JS version that still supports the drawing tools.
- Update Storybook and Docs for AdvancedMarker, DrawingManager, and BicyclingLayer behavior, including map ID/library requirements and a visible cycling coverage location.
- Enable Storybook Docs rendering and point stories at the actual package components while keeping the shared canvas wrapper.
- Remove stale wording from Docs so component pages stay aligned with the package API.

## Validation
- `pnpm check`
- `pnpm lint` (passes with existing warnings in unrelated files)
- `pnpm test`
- `pnpm build --filter=storybook`
- `pnpm build --filter=docs`
- Browser-verified AdvancedMarker, BicyclingLayer, and DrawingManager stories with an API key; no console errors observed.
- Browser-verified Storybook Docs pages render headings and props tables for multiple components.