### PR TITLE
Fix Storybook docs rendering

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/svelte-vite';
 
 const config: StorybookConfig = {
 	stories: ['../src/**/*.stories.@(ts|svelte)'],
-	addons: [],
+	addons: ['@storybook/addon-docs'],
 	framework: {
 		name: '@storybook/svelte-vite',
 		options: {}

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -12,9 +12,10 @@
 		"svelte-google-maps-api": "workspace:*"
 	},
 	"devDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^5.0.3",
+		"@storybook/addon-docs": "8.6.18",
 		"@storybook/svelte": "^8.6.14",
 		"@storybook/svelte-vite": "^8.6.14",
+		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"storybook": "^8.6.14",
 		"svelte": "^5.28.2",
 		"typescript": "^5.0.0",

--- a/apps/storybook/src/stories/APIProvider.stories.ts
+++ b/apps/storybook/src/stories/APIProvider.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { APIProvider } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/APIProvider',
-	component: ComponentStory,
-	args: { componentName: 'APIProvider' }
-} satisfies Meta<typeof ComponentStory>;
+	component: APIProvider,
+	tags: ['autodocs']
+} satisfies Meta<typeof APIProvider>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'APIProvider' }
+	})
+};

--- a/apps/storybook/src/stories/AdvancedMarker.stories.ts
+++ b/apps/storybook/src/stories/AdvancedMarker.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { AdvancedMarker } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/AdvancedMarker',
-	component: ComponentStory,
-	args: { componentName: 'AdvancedMarker' }
-} satisfies Meta<typeof ComponentStory>;
+	component: AdvancedMarker,
+	tags: ['autodocs']
+} satisfies Meta<typeof AdvancedMarker>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'AdvancedMarker' }
+	})
+};

--- a/apps/storybook/src/stories/Autocomplete.stories.ts
+++ b/apps/storybook/src/stories/Autocomplete.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Autocomplete } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/Autocomplete',
-	component: ComponentStory,
-	args: { componentName: 'Autocomplete' }
-} satisfies Meta<typeof ComponentStory>;
+	component: Autocomplete,
+	tags: ['autodocs']
+} satisfies Meta<typeof Autocomplete>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'Autocomplete' }
+	})
+};

--- a/apps/storybook/src/stories/BicyclingLayer.stories.ts
+++ b/apps/storybook/src/stories/BicyclingLayer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { BicyclingLayer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/BicyclingLayer',
-	component: ComponentStory,
-	args: { componentName: 'BicyclingLayer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: BicyclingLayer,
+	tags: ['autodocs']
+} satisfies Meta<typeof BicyclingLayer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'BicyclingLayer' }
+	})
+};

--- a/apps/storybook/src/stories/Circle.stories.ts
+++ b/apps/storybook/src/stories/Circle.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Circle } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/Circle',
-	component: ComponentStory,
-	args: { componentName: 'Circle' }
-} satisfies Meta<typeof ComponentStory>;
+	component: Circle,
+	tags: ['autodocs']
+} satisfies Meta<typeof Circle>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'Circle' }
+	})
+};

--- a/apps/storybook/src/stories/Data.stories.ts
+++ b/apps/storybook/src/stories/Data.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Data } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/Data',
-	component: ComponentStory,
-	args: { componentName: 'Data' }
-} satisfies Meta<typeof ComponentStory>;
+	component: Data,
+	tags: ['autodocs']
+} satisfies Meta<typeof Data>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'Data' }
+	})
+};

--- a/apps/storybook/src/stories/DirectionsRenderer.stories.ts
+++ b/apps/storybook/src/stories/DirectionsRenderer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { DirectionsRenderer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/DirectionsRenderer',
-	component: ComponentStory,
-	args: { componentName: 'DirectionsRenderer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: DirectionsRenderer,
+	tags: ['autodocs']
+} satisfies Meta<typeof DirectionsRenderer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'DirectionsRenderer' }
+	})
+};

--- a/apps/storybook/src/stories/DirectionsService.stories.ts
+++ b/apps/storybook/src/stories/DirectionsService.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { DirectionsService } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/DirectionsService',
-	component: ComponentStory,
-	args: { componentName: 'DirectionsService' }
-} satisfies Meta<typeof ComponentStory>;
+	component: DirectionsService,
+	tags: ['autodocs']
+} satisfies Meta<typeof DirectionsService>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'DirectionsService' }
+	})
+};

--- a/apps/storybook/src/stories/DistanceMatrixService.stories.ts
+++ b/apps/storybook/src/stories/DistanceMatrixService.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { DistanceMatrixService } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/DistanceMatrixService',
-	component: ComponentStory,
-	args: { componentName: 'DistanceMatrixService' }
-} satisfies Meta<typeof ComponentStory>;
+	component: DistanceMatrixService,
+	tags: ['autodocs']
+} satisfies Meta<typeof DistanceMatrixService>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'DistanceMatrixService' }
+	})
+};

--- a/apps/storybook/src/stories/DrawingManager.stories.ts
+++ b/apps/storybook/src/stories/DrawingManager.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { DrawingManager } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/DrawingManager',
-	component: ComponentStory,
-	args: { componentName: 'DrawingManager' }
-} satisfies Meta<typeof ComponentStory>;
+	component: DrawingManager,
+	tags: ['autodocs']
+} satisfies Meta<typeof DrawingManager>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'DrawingManager' }
+	})
+};

--- a/apps/storybook/src/stories/GoogleMap.stories.ts
+++ b/apps/storybook/src/stories/GoogleMap.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { GoogleMap } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/GoogleMap',
-	component: ComponentStory,
-	args: { componentName: 'GoogleMap' }
-} satisfies Meta<typeof ComponentStory>;
+	component: GoogleMap,
+	tags: ['autodocs']
+} satisfies Meta<typeof GoogleMap>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'GoogleMap' }
+	})
+};

--- a/apps/storybook/src/stories/GoogleMarkerClusterer.stories.ts
+++ b/apps/storybook/src/stories/GoogleMarkerClusterer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { GoogleMarkerClusterer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/GoogleMarkerClusterer',
-	component: ComponentStory,
-	args: { componentName: 'GoogleMarkerClusterer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: GoogleMarkerClusterer,
+	tags: ['autodocs']
+} satisfies Meta<typeof GoogleMarkerClusterer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'GoogleMarkerClusterer' }
+	})
+};

--- a/apps/storybook/src/stories/GroundOverlay.stories.ts
+++ b/apps/storybook/src/stories/GroundOverlay.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { GroundOverlay } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/GroundOverlay',
-	component: ComponentStory,
-	args: { componentName: 'GroundOverlay' }
-} satisfies Meta<typeof ComponentStory>;
+	component: GroundOverlay,
+	tags: ['autodocs']
+} satisfies Meta<typeof GroundOverlay>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'GroundOverlay' }
+	})
+};

--- a/apps/storybook/src/stories/HeatmapLayer.stories.ts
+++ b/apps/storybook/src/stories/HeatmapLayer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { HeatmapLayer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/HeatmapLayer',
-	component: ComponentStory,
-	args: { componentName: 'HeatmapLayer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: HeatmapLayer,
+	tags: ['autodocs']
+} satisfies Meta<typeof HeatmapLayer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'HeatmapLayer' }
+	})
+};

--- a/apps/storybook/src/stories/InfoBox.stories.ts
+++ b/apps/storybook/src/stories/InfoBox.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { InfoBox } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/InfoBox',
-	component: ComponentStory,
-	args: { componentName: 'InfoBox' }
-} satisfies Meta<typeof ComponentStory>;
+	component: InfoBox,
+	tags: ['autodocs']
+} satisfies Meta<typeof InfoBox>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'InfoBox' }
+	})
+};

--- a/apps/storybook/src/stories/InfoWindow.stories.ts
+++ b/apps/storybook/src/stories/InfoWindow.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { InfoWindow } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/InfoWindow',
-	component: ComponentStory,
-	args: { componentName: 'InfoWindow' }
-} satisfies Meta<typeof ComponentStory>;
+	component: InfoWindow,
+	tags: ['autodocs']
+} satisfies Meta<typeof InfoWindow>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'InfoWindow' }
+	})
+};

--- a/apps/storybook/src/stories/KmlLayer.stories.ts
+++ b/apps/storybook/src/stories/KmlLayer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { KmlLayer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/KmlLayer',
-	component: ComponentStory,
-	args: { componentName: 'KmlLayer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: KmlLayer,
+	tags: ['autodocs']
+} satisfies Meta<typeof KmlLayer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'KmlLayer' }
+	})
+};

--- a/apps/storybook/src/stories/MapControl.stories.ts
+++ b/apps/storybook/src/stories/MapControl.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { MapControl } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/MapControl',
-	component: ComponentStory,
-	args: { componentName: 'MapControl' }
-} satisfies Meta<typeof ComponentStory>;
+	component: MapControl,
+	tags: ['autodocs']
+} satisfies Meta<typeof MapControl>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'MapControl' }
+	})
+};

--- a/apps/storybook/src/stories/Marker.stories.ts
+++ b/apps/storybook/src/stories/Marker.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Marker } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/Marker',
-	component: ComponentStory,
-	args: { componentName: 'Marker' }
-} satisfies Meta<typeof ComponentStory>;
+	component: Marker,
+	tags: ['autodocs']
+} satisfies Meta<typeof Marker>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'Marker' }
+	})
+};

--- a/apps/storybook/src/stories/MarkerClusterer.stories.ts
+++ b/apps/storybook/src/stories/MarkerClusterer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { MarkerClusterer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/MarkerClusterer',
-	component: ComponentStory,
-	args: { componentName: 'MarkerClusterer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: MarkerClusterer,
+	tags: ['autodocs']
+} satisfies Meta<typeof MarkerClusterer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'MarkerClusterer' }
+	})
+};

--- a/apps/storybook/src/stories/OverlayView.stories.ts
+++ b/apps/storybook/src/stories/OverlayView.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { OverlayView } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/OverlayView',
-	component: ComponentStory,
-	args: { componentName: 'OverlayView' }
-} satisfies Meta<typeof ComponentStory>;
+	component: OverlayView,
+	tags: ['autodocs']
+} satisfies Meta<typeof OverlayView>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'OverlayView' }
+	})
+};

--- a/apps/storybook/src/stories/Polygon.stories.ts
+++ b/apps/storybook/src/stories/Polygon.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Polygon } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/Polygon',
-	component: ComponentStory,
-	args: { componentName: 'Polygon' }
-} satisfies Meta<typeof ComponentStory>;
+	component: Polygon,
+	tags: ['autodocs']
+} satisfies Meta<typeof Polygon>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'Polygon' }
+	})
+};

--- a/apps/storybook/src/stories/Polyline.stories.ts
+++ b/apps/storybook/src/stories/Polyline.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Polyline } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/Polyline',
-	component: ComponentStory,
-	args: { componentName: 'Polyline' }
-} satisfies Meta<typeof ComponentStory>;
+	component: Polyline,
+	tags: ['autodocs']
+} satisfies Meta<typeof Polyline>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'Polyline' }
+	})
+};

--- a/apps/storybook/src/stories/Rectangle.stories.ts
+++ b/apps/storybook/src/stories/Rectangle.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { Rectangle } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/Rectangle',
-	component: ComponentStory,
-	args: { componentName: 'Rectangle' }
-} satisfies Meta<typeof ComponentStory>;
+	component: Rectangle,
+	tags: ['autodocs']
+} satisfies Meta<typeof Rectangle>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'Rectangle' }
+	})
+};

--- a/apps/storybook/src/stories/StandaloneSearchBox.stories.ts
+++ b/apps/storybook/src/stories/StandaloneSearchBox.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { StandaloneSearchBox } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/StandaloneSearchBox',
-	component: ComponentStory,
-	args: { componentName: 'StandaloneSearchBox' }
-} satisfies Meta<typeof ComponentStory>;
+	component: StandaloneSearchBox,
+	tags: ['autodocs']
+} satisfies Meta<typeof StandaloneSearchBox>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'StandaloneSearchBox' }
+	})
+};

--- a/apps/storybook/src/stories/StreetViewPanorama.stories.ts
+++ b/apps/storybook/src/stories/StreetViewPanorama.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { StreetViewPanorama } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/StreetViewPanorama',
-	component: ComponentStory,
-	args: { componentName: 'StreetViewPanorama' }
-} satisfies Meta<typeof ComponentStory>;
+	component: StreetViewPanorama,
+	tags: ['autodocs']
+} satisfies Meta<typeof StreetViewPanorama>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'StreetViewPanorama' }
+	})
+};

--- a/apps/storybook/src/stories/StreetViewService.stories.ts
+++ b/apps/storybook/src/stories/StreetViewService.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { StreetViewService } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/StreetViewService',
-	component: ComponentStory,
-	args: { componentName: 'StreetViewService' }
-} satisfies Meta<typeof ComponentStory>;
+	component: StreetViewService,
+	tags: ['autodocs']
+} satisfies Meta<typeof StreetViewService>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'StreetViewService' }
+	})
+};

--- a/apps/storybook/src/stories/TrafficLayer.stories.ts
+++ b/apps/storybook/src/stories/TrafficLayer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { TrafficLayer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/TrafficLayer',
-	component: ComponentStory,
-	args: { componentName: 'TrafficLayer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: TrafficLayer,
+	tags: ['autodocs']
+} satisfies Meta<typeof TrafficLayer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'TrafficLayer' }
+	})
+};

--- a/apps/storybook/src/stories/TransitLayer.stories.ts
+++ b/apps/storybook/src/stories/TransitLayer.stories.ts
@@ -1,13 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
+import { TransitLayer } from 'svelte-google-maps-api';
 import ComponentStory from './ComponentStory.svelte';
 
 const meta = {
 	title: 'Components/TransitLayer',
-	component: ComponentStory,
-	args: { componentName: 'TransitLayer' }
-} satisfies Meta<typeof ComponentStory>;
+	component: TransitLayer,
+	tags: ['autodocs']
+} satisfies Meta<typeof TransitLayer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	render: () => ({
+		Component: ComponentStory,
+		props: { componentName: 'TransitLayer' }
+	})
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
       '@sveltepress/theme-default':
         specifier: ^6.0.1
-        version: 6.0.2(@algolia/client-search@5.24.0)(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(@sveltepress/vite@1.2.1(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(rollup@2.79.2)(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(postcss@8.5.3)(rollup@2.79.2)(search-insights@2.17.3)(svelte@5.28.2)(typescript@5.8.3)(vite-plugin-pwa@0.21.2(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))(workbox-build@7.3.0)(workbox-window@7.3.0))(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
+        version: 6.0.2(b69e044bae29a31e2c7b79de07eae4d2)
       '@sveltepress/vite':
         specifier: ^1.2.1
         version: 1.2.1(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(rollup@2.79.2)(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
@@ -152,6 +152,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/svelte-google-maps-api
     devDependencies:
+      '@storybook/addon-docs':
+        specifier: 8.6.18
+        version: 8.6.18(@types/react@19.2.15)(storybook@8.6.18(prettier@3.5.3))
       '@storybook/svelte':
         specifier: ^8.6.14
         version: 8.6.18(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)
@@ -1428,6 +1431,12 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@modelcontextprotocol/sdk@1.11.0':
     resolution: {integrity: sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==}
     engines: {node: '>=18'}
@@ -1627,6 +1636,23 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@storybook/addon-docs@8.6.18':
+    resolution: {integrity: sha512-55ADer0yNmmeR928Y3UAv3r4i7bJSd9LwywsQ+lRol/FNe0ZcwLEz31xL+jVsqQFNnDh/imsDIp8aYapGMtfEQ==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/blocks@8.6.18':
+    resolution: {integrity: sha512-esZv4msPQ9LxgTb8YUIZhhxVMuI6BPi5bkXtk8c7w7sWuAsqsCe/RnVInn7ooUry2gjnD4hd9+8Eqj0b8oTVoA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^8.6.18
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@storybook/builder-vite@8.6.18':
     resolution: {integrity: sha512-XLqnOv4C36jlTd4uC8xpWBxv+7GV4/05zWJ0wAcU4qflorropUTirt4UQPGkwIzi+BVAhs9pJj+m4k0IWJtpHg==}
     peerDependencies:
@@ -1657,6 +1683,13 @@ packages:
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
+  '@storybook/icons@1.6.0':
+    resolution: {integrity: sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+
   '@storybook/manager-api@8.6.18':
     resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
     peerDependencies:
@@ -1666,6 +1699,13 @@ packages:
     resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/react-dom-shim@8.6.18':
+    resolution: {integrity: sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^8.6.18
 
   '@storybook/svelte-vite@8.6.18':
     resolution: {integrity: sha512-iKhtHWtgZ7LCB0qn9Rjwngnn9dZWqFLAQfWnbrMvnpWF83xKyDp+baoifKiQm7nasf/XtC3wLpN/BKoEGTMEQQ==}
@@ -1833,6 +1873,9 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1841,6 +1884,9 @@ packages:
 
   '@types/pug@2.0.10':
     resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2456,6 +2502,9 @@ packages:
   cssstyle@4.3.1:
     resolution: {integrity: sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==}
     engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -4034,11 +4083,20 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -4210,6 +4268,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
@@ -5997,9 +6058,9 @@ snapshots:
 
   '@docsearch/css@3.9.0': {}
 
-  '@docsearch/js@3.9.0(@algolia/client-search@5.24.0)(search-insights@2.17.3)':
+  '@docsearch/js@3.9.0(@algolia/client-search@5.24.0)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)':
     dependencies:
-      '@docsearch/react': 3.9.0(@algolia/client-search@5.24.0)(search-insights@2.17.3)
+      '@docsearch/react': 3.9.0(@algolia/client-search@5.24.0)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)
       preact: 10.26.5
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -6008,13 +6069,16 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@docsearch/react@3.9.0(@algolia/client-search@5.24.0)(search-insights@2.17.3)':
+  '@docsearch/react@3.9.0(@algolia/client-search@5.24.0)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.24.0)(algoliasearch@5.24.0)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.24.0)(algoliasearch@5.24.0)
       '@docsearch/css': 3.9.0
       algoliasearch: 5.24.0
     optionalDependencies:
+      '@types/react': 19.2.15
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -6405,6 +6469,12 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.15
+      react: 19.2.6
+
   '@modelcontextprotocol/sdk@1.11.0':
     dependencies:
       content-type: 1.0.5
@@ -6590,6 +6660,28 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@storybook/addon-docs@8.6.18(@types/react@19.2.15)(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@storybook/blocks': 8.6.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.5.3))
+      '@storybook/react-dom-shim': 8.6.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@8.6.18(prettier@3.5.3))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 8.6.18(prettier@3.5.3)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@storybook/blocks@8.6.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      '@storybook/icons': 1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      storybook: 8.6.18(prettier@3.5.3)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
       '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.5.3))
@@ -6634,12 +6726,23 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
+  '@storybook/icons@1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@storybook/manager-api@8.6.18(storybook@8.6.18(prettier@3.5.3))':
     dependencies:
       storybook: 8.6.18(prettier@3.5.3)
 
   '@storybook/preview-api@8.6.18(storybook@8.6.18(prettier@3.5.3))':
     dependencies:
+      storybook: 8.6.18(prettier@3.5.3)
+
+  '@storybook/react-dom-shim@8.6.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@8.6.18(prettier@3.5.3))':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       storybook: 8.6.18(prettier@3.5.3)
 
   '@storybook/svelte-vite@8.6.18(@babel/core@7.27.1)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)))(postcss-load-config@3.1.4(postcss@8.5.3))(postcss@8.5.3)(storybook@8.6.18(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@20.17.32)(jiti@1.21.7)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))':
@@ -6797,10 +6900,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltepress/theme-default@6.0.2(@algolia/client-search@5.24.0)(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(@sveltepress/vite@1.2.1(@sveltejs/kit@2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(rollup@2.79.2)(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(postcss@8.5.3)(rollup@2.79.2)(search-insights@2.17.3)(svelte@5.28.2)(typescript@5.8.3)(vite-plugin-pwa@0.21.2(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))(workbox-build@7.3.0)(workbox-window@7.3.0))(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))':
+  '@sveltepress/theme-default@6.0.2(b69e044bae29a31e2c7b79de07eae4d2)':
     dependencies:
       '@docsearch/css': 3.9.0
-      '@docsearch/js': 3.9.0(@algolia/client-search@5.24.0)(search-insights@2.17.3)
+      '@docsearch/js': 3.9.0(@algolia/client-search@5.24.0)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)
       '@shikijs/twoslash': 1.29.2(typescript@5.8.3)
       '@sveltejs/kit': 2.20.8(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0)))(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
       '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.28.2)(vite@5.4.19(@types/node@20.17.32)(terser@5.39.0))
@@ -6941,6 +7044,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/mdx@2.0.13': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/node@20.17.32':
@@ -6948,6 +7053,10 @@ snapshots:
       undici-types: 6.19.8
 
   '@types/pug@2.0.10': {}
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
 
@@ -7715,6 +7824,8 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.1.7
       rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
 
   data-urls@5.0.0:
     dependencies:
@@ -9696,9 +9807,16 @@ snapshots:
       iconv-lite: 0.6.3
       unpipe: 1.0.0
 
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react@19.2.6: {}
 
   readdirp@3.6.0:
     dependencies:
@@ -9952,6 +10070,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
 
   search-insights@2.17.3: {}
 


### PR DESCRIPTION
## Summary
- Enable the Storybook Docs addon so generated Docs tabs render actual content.
- Point every component story at its package component for autodocs metadata.
- Keep the existing shared Storybook canvas wrapper via each story's render function.

## Validation
- `pnpm check`
- `pnpm lint` (passes with existing warnings in unrelated files)
- `pnpm test`
- `pnpm build --filter=storybook`
- Browser-verified Storybook Docs pages render component headings and props tables for APIProvider, AdvancedMarker, BicyclingLayer, DrawingManager, and GoogleMap.